### PR TITLE
fix(skills): stabilize corner-random OR behavior for Swinging Maestro

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ scripts/skill-lists/*.json
 /blob-report/
 /playwright/.cache/
 /playwright/.auth/
+
+
+docs/reports/

--- a/docs/reference/agent-skills/best-practices.md
+++ b/docs/reference/agent-skills/best-practices.md
@@ -1,0 +1,268 @@
+> ## Documentation Index
+>
+> Fetch the complete documentation index at: https://agentskills.io/llms.txt
+> Use this file to discover all available pages before exploring further.
+
+# Best practices for skill creators
+
+> How to write skills that are well-scoped and calibrated to the task.
+
+## Start from real expertise
+
+A common pitfall in skill creation is asking an LLM to generate a skill without providing domain-specific context — relying solely on the LLM's general training knowledge. The result is vague, generic procedures ("handle errors appropriately," "follow best practices for authentication") rather than the specific API patterns, edge cases, and project conventions that make a skill valuable.
+
+Effective skills are grounded in real expertise. The key is feeding domain-specific context into the creation process.
+
+### Extract from a hands-on task
+
+Complete a real task in conversation with an agent, providing context, corrections, and preferences along the way. Then extract the reusable pattern into a skill. Pay attention to:
+
+- **Steps that worked** — the sequence of actions that led to success
+- **Corrections you made** — places where you steered the agent's approach (e.g., "use library X instead of Y," "check for edge case Z")
+- **Input/output formats** — what the data looked like going in and coming out
+- **Context you provided** — project-specific facts, conventions, or constraints the agent didn't already know
+
+### Synthesize from existing project artifacts
+
+When you have a body of existing knowledge, you can feed it into an LLM and ask it to synthesize a skill. A data-pipeline skill synthesized from your team's actual incident reports and runbooks will outperform one synthesized from a generic "data engineering best practices" article, because it captures _your_ schemas, failure modes, and recovery procedures. The key is project-specific material, not generic references.
+
+Good source material includes:
+
+- Internal documentation, runbooks, and style guides
+- API specifications, schemas, and configuration files
+- Code review comments and issue trackers (captures recurring concerns and reviewer expectations)
+- Version control history, especially patches and fixes (reveals patterns through what actually changed)
+- Real-world failure cases and their resolutions
+
+## Refine with real execution
+
+The first draft of a skill usually needs refinement. Run the skill against real tasks, then feed the results — all of them, not just failures — back into the creation process. Ask: what triggered false positives? What was missed? What could be cut?
+
+Even a single pass of execute-then-revise noticeably improves quality, and complex domains often benefit from several.
+
+<Tip>
+  Read agent execution traces, not just final outputs. If the agent wastes time on unproductive steps, common causes include instructions that are too vague (the agent tries several approaches before finding one that works), instructions that don't apply to the current task (the agent follows them anyway), or too many options presented without a clear default.
+</Tip>
+
+For a more structured approach to iteration, including test cases, assertions, and grading, see [Evaluating skill output quality](/skill-creation/evaluating-skills).
+
+## Spending context wisely
+
+Once a skill activates, its full `SKILL.md` body loads into the agent's context window alongside conversation history, system context, and other active skills. Every token in your skill competes for the agent's attention with everything else in that window.
+
+### Add what the agent lacks, omit what it knows
+
+Focus on what the agent _wouldn't_ know without your skill: project-specific conventions, domain-specific procedures, non-obvious edge cases, and the particular tools or APIs to use. You don't need to explain what a PDF is, how HTTP works, or what a database migration does.
+
+````markdown theme={null}
+<!-- Too verbose — the agent already knows what PDFs are -->
+
+## Extract PDF text
+
+PDF (Portable Document Format) files are a common file format that contains
+text, images, and other content. To extract text from a PDF, you'll need to
+use a library. pdfplumber is recommended because it handles most cases well.
+
+<!-- Better — jumps straight to what the agent wouldn't know on its own -->
+
+## Extract PDF text
+
+Use pdfplumber for text extraction. For scanned documents, fall back to
+pdf2image with pytesseract.
+
+```python
+import pdfplumber
+
+with pdfplumber.open("file.pdf") as pdf:
+    text = pdf.pages[0].extract_text()
+```
+````
+
+Ask yourself about each piece of content: "Would the agent get this wrong without this instruction?" If the answer is no, cut it. If you're unsure, test it. And if the agent already handles the entire task well without the skill, the skill may not be adding value. See [Evaluating skill output quality](/skill-creation/evaluating-skills) for how to test this systematically.
+
+### Design coherent units
+
+Deciding what a skill should cover is like deciding what a function should do: you want it to encapsulate a coherent unit of work that composes well with other skills. Skills scoped too narrowly force multiple skills to load for a single task, risking overhead and conflicting instructions. Skills scoped too broadly become hard to activate precisely. A skill for querying a database and formatting the results may be one coherent unit, while a skill that also covers database administration is probably trying to do too much.
+
+### Aim for moderate detail
+
+Overly comprehensive skills can hurt more than they help — the agent struggles to extract what's relevant and may pursue unproductive paths triggered by instructions that don't apply to the current task. Concise, stepwise guidance with a working example tends to outperform exhaustive documentation. When you find yourself covering every edge case, consider whether most are better handled by the agent's own judgment.
+
+### Structure large skills with progressive disclosure
+
+The [specification](/specification#progressive-disclosure) recommends keeping `SKILL.md` under 500 lines and 5,000 tokens — just the core instructions the agent needs on every run. When a skill legitimately needs more content, move detailed reference material to separate files in `references/` or similar directories.
+
+The key is telling the agent _when_ to load each file. "Read `references/api-errors.md` if the API returns a non-200 status code" is more useful than a generic "see references/ for details." This lets the agent load context on demand rather than up front, which is how [progressive disclosure](/what-are-skills#how-skills-work) is designed to work.
+
+## Calibrating control
+
+Not every part of a skill needs the same level of prescriptiveness. Match the specificity of your instructions to the fragility of the task.
+
+### Match specificity to fragility
+
+**Give the agent freedom** when multiple approaches are valid and the task tolerates variation. For flexible instructions, explaining _why_ can be more effective than rigid directives — an agent that understands the purpose behind an instruction makes better context-dependent decisions. A code review skill can describe what to look for without prescribing exact steps:
+
+```markdown theme={null}
+## Code review process
+
+1. Check all database queries for SQL injection (use parameterized queries)
+2. Verify authentication checks on every endpoint
+3. Look for race conditions in concurrent code paths
+4. Confirm error messages don't leak internal details
+```
+
+**Be prescriptive** when operations are fragile, consistency matters, or a specific sequence must be followed:
+
+````markdown theme={null}
+## Database migration
+
+Run exactly this sequence:
+
+```bash
+python scripts/migrate.py --verify --backup
+```
+
+Do not modify the command or add additional flags.
+````
+
+Most skills have a mix. Calibrate each part independently.
+
+### Provide defaults, not menus
+
+When multiple tools or approaches could work, pick a default and mention alternatives briefly rather than presenting them as equal options.
+
+````markdown theme={null}
+<!-- Too many options -->
+
+You can use pypdf, pdfplumber, PyMuPDF, or pdf2image...
+
+<!-- Clear default with escape hatch -->
+
+Use pdfplumber for text extraction:
+
+```python
+import pdfplumber
+```
+
+For scanned PDFs requiring OCR, use pdf2image with pytesseract instead.
+````
+
+### Favor procedures over declarations
+
+A skill should teach the agent _how to approach_ a class of problems, not _what to produce_ for a specific instance. Compare:
+
+```markdown theme={null}
+<!-- Specific answer — only useful for this exact task -->
+
+Join the `orders` table to `customers` on `customer_id`, filter where
+`region = 'EMEA'`, and sum the `amount` column.
+
+<!-- Reusable method — works for any analytical query -->
+
+1. Read the schema from `references/schema.yaml` to find relevant tables
+2. Join tables using the `_id` foreign key convention
+3. Apply any filters from the user's request as WHERE clauses
+4. Aggregate numeric columns as needed and format as a markdown table
+```
+
+This doesn't mean skills can't include specific details — output format templates (see [Templates for output format](#templates-for-output-format)), constraints like "never output PII," and tool-specific instructions are all valuable. The point is that the _approach_ should generalize even when individual details are specific.
+
+## Patterns for effective instructions
+
+These are reusable techniques for structuring skill content. Not every skill needs all of them — use the ones that fit your task.
+
+### Templates for output format
+
+When you need the agent to produce output in a specific format, provide a template. This is more reliable than describing the format in prose, because agents pattern-match well against concrete structures. Short templates can live inline in `SKILL.md`; for longer templates, or templates only needed in certain cases, store them in `assets/` and reference them from `SKILL.md` so they only load when needed.
+
+````markdown theme={null}
+## Report structure
+
+Use this template, adapting sections as needed for the specific analysis:
+
+```markdown
+# [Analysis Title]
+
+## Executive summary
+
+[One-paragraph overview of key findings]
+
+## Key findings
+
+- Finding 1 with supporting data
+- Finding 2 with supporting data
+
+## Recommendations
+
+1. Specific actionable recommendation
+2. Specific actionable recommendation
+```
+````
+
+### Checklists for multi-step workflows
+
+An explicit checklist helps the agent track progress and avoid skipping steps, especially when steps have dependencies or validation gates.
+
+```markdown theme={null}
+## Form processing workflow
+
+Progress:
+
+- [ ] Step 1: Analyze the form (run `scripts/analyze_form.py`)
+- [ ] Step 2: Create field mapping (edit `fields.json`)
+- [ ] Step 3: Validate mapping (run `scripts/validate_fields.py`)
+- [ ] Step 4: Fill the form (run `scripts/fill_form.py`)
+- [ ] Step 5: Verify output (run `scripts/verify_output.py`)
+```
+
+### Validation loops
+
+Instruct the agent to validate its own work before moving on. The pattern is: do the work, run a validator (a script, a reference checklist, or a self-check), fix any issues, and repeat until validation passes.
+
+```markdown theme={null}
+## Editing workflow
+
+1. Make your edits
+2. Run validation: `python scripts/validate.py output/`
+3. If validation fails:
+   - Review the error message
+   - Fix the issues
+   - Run validation again
+4. Only proceed when validation passes
+```
+
+A reference document can also serve as the "validator" — instruct the agent to check its work against the reference before finalizing.
+
+### Plan-validate-execute
+
+For batch or destructive operations, have the agent create an intermediate plan in a structured format, validate it against a source of truth, and only then execute.
+
+```markdown theme={null}
+## PDF form filling
+
+1. Extract form fields: `python scripts/analyze_form.py input.pdf` → `form_fields.json`
+   (lists every field name, type, and whether it's required)
+2. Create `field_values.json` mapping each field name to its intended value
+3. Validate: `python scripts/validate_fields.py form_fields.json field_values.json`
+   (checks that every field name exists in the form, types are compatible, and
+   required fields aren't missing)
+4. If validation fails, revise `field_values.json` and re-validate
+5. Fill the form: `python scripts/fill_form.py input.pdf field_values.json output.pdf`
+```
+
+The key ingredient is step 3: a validation script that checks the plan (`field_values.json`) against the source of truth (`form_fields.json`). Errors like "Field 'signature_date' not found — available fields: customer_name, order_total, signature_date_signed" give the agent enough information to self-correct.
+
+### Bundling reusable scripts
+
+When [iterating on a skill](/skill-creation/evaluating-skills), compare the agent's execution traces across test cases. If you notice the agent independently reinventing the same logic each run — building charts, parsing a specific format, validating output — that's a signal to write a tested script once and bundle it in `scripts/`.
+
+For more on designing and bundling scripts, see [Using scripts in skills](/skill-creation/using-scripts).
+
+## Next steps
+
+Once you have a working skill, two guides can help you refine it further:
+
+- **[Evaluating skill output quality](/skill-creation/evaluating-skills)** — Set up test cases, grade results, and iterate systematically.
+- **[Optimizing skill descriptions](/skill-creation/optimizing-descriptions)** — Test and improve your skill's `description` field so it triggers on the right prompts.
+
+Built with [Mintlify](https://mintlify.com).

--- a/docs/reference/agent-skills/optimizing-descriptions.md
+++ b/docs/reference/agent-skills/optimizing-descriptions.md
@@ -1,0 +1,202 @@
+> ## Documentation Index
+>
+> Fetch the complete documentation index at: https://agentskills.io/llms.txt
+> Use this file to discover all available pages before exploring further.
+
+# Optimizing skill descriptions
+
+> How to improve your skill's description so it triggers reliably on relevant prompts.
+
+A skill only helps if it gets activated. The `description` field in your `SKILL.md` frontmatter is the primary mechanism agents use to decide whether to load a skill for a given task. An under-specified description means the skill won't trigger when it should; an over-broad description means it triggers when it shouldn't.
+
+This guide covers how to systematically test and improve your skill's description for triggering accuracy.
+
+## How skill triggering works
+
+Agents use [progressive disclosure](/what-are-skills#how-skills-work) to manage context. At startup, they load only the `name` and `description` of each available skill — just enough to decide when a skill might be relevant. When a user's task matches a description, the agent reads the full `SKILL.md` into context and follows its instructions.
+
+This means the description carries the entire burden of triggering. If the description doesn't convey when the skill is useful, the agent won't know to reach for it.
+
+One important nuance: agents typically only consult skills for tasks that require knowledge or capabilities beyond what they can handle alone. A simple, one-step request like "read this PDF" may not trigger a PDF skill even if the description matches perfectly, because the agent can handle it with basic tools. Tasks that involve specialized knowledge — an unfamiliar API, a domain-specific workflow, or an uncommon format — are where a well-written description can make the difference.
+
+## Writing effective descriptions
+
+Before testing, it helps to know what a good description looks like. A few principles:
+
+- **Use imperative phrasing.** Frame the description as an instruction to the agent: "Use this skill when..." rather than "This skill does..." The agent is deciding whether to act, so tell it when to act.
+- **Focus on user intent, not implementation.** Describe what the user is trying to achieve, not the skill's internal mechanics. The agent matches against what the user asked for.
+- **Err on the side of being pushy.** Explicitly list contexts where the skill applies, including cases where the user doesn't name the domain directly: "even if they don't explicitly mention 'CSV' or 'analysis.'"
+- **Keep it concise.** A few sentences to a short paragraph is usually right — long enough to cover the skill's scope, short enough that it doesn't bloat the agent's context across many skills. The [specification](/specification#description-field) enforces a hard limit of 1024 characters.
+
+## Designing trigger eval queries
+
+To test triggering, you need a set of eval queries — realistic user prompts labeled with whether they should or shouldn't trigger your skill.
+
+```json eval_queries.json theme={null}
+[
+  {
+    "query": "I've got a spreadsheet in ~/data/q4_results.xlsx with revenue in col C and expenses in col D — can you add a profit margin column and highlight anything under 10%?",
+    "should_trigger": true
+  },
+  { "query": "whats the quickest way to convert this json file to yaml", "should_trigger": false }
+]
+```
+
+Aim for about 20 queries: 8-10 that should trigger and 8-10 that shouldn't.
+
+### Should-trigger queries
+
+These test whether the description captures the skill's scope. Vary them along several axes:
+
+- **Phrasing**: some formal, some casual, some with typos or abbreviations.
+- **Explicitness**: some name the skill's domain directly ("analyze this CSV"), others describe the need without naming it ("my boss wants a chart from this data file").
+- **Detail**: mix terse prompts with context-heavy ones — a short "analyze my sales CSV and make a chart" alongside a longer message with file paths, column names, and backstory.
+- **Complexity**: vary the number of steps and decision points. Include single-step tasks alongside multi-step workflows to test whether the agent can discern the skill is relevant when the task it addresses is buried in a larger chain.
+
+The most useful should-trigger queries are ones where the skill would help but the connection isn't obvious from the query alone. These are the cases where description wording makes the difference — if the query already asks for exactly what the skill does, any reasonable description would trigger.
+
+### Should-not-trigger queries
+
+The most valuable negative test cases are **near-misses** — queries that share keywords or concepts with your skill but actually need something different. These test whether the description is precise, not just broad.
+
+For a CSV analysis skill, weak negative examples would be:
+
+- `"Write a fibonacci function"` — obviously irrelevant, tests nothing.
+- `"What's the weather today?"` — no keyword overlap, too easy.
+
+Strong negative examples:
+
+- `"I need to update the formulas in my Excel budget spreadsheet"` — shares "spreadsheet" and "data" concepts, but needs Excel editing, not CSV analysis.
+- `"can you write a python script that reads a csv and uploads each row to our postgres database"` — involves CSV, but the task is database ETL, not analysis.
+
+### Tips for realism
+
+Real user prompts contain context that generic test queries lack. Include:
+
+- File paths (`~/Downloads/report_final_v2.xlsx`)
+- Personal context (`"my manager asked me to..."`)
+- Specific details (column names, company names, data values)
+- Casual language, abbreviations, and occasional typos
+
+## Testing whether a description triggers
+
+The basic approach: run each query through your agent with the skill installed and observe whether the agent invokes it. Make sure the skill is registered and discoverable by your agent — how this works varies by client (e.g., a skills directory, a configuration file, or a CLI flag).
+
+Most agent clients provide some form of observability — execution logs, tool call histories, or verbose output — that lets you see which skills were consulted during a run. Check your client's documentation for details. The skill triggered if the agent loaded your skill's `SKILL.md`; it didn't trigger if the agent proceeded without consulting it.
+
+A query "passes" if:
+
+- `should_trigger` is `true` and the skill was invoked, or
+- `should_trigger` is `false` and the skill was not invoked.
+
+### Running multiple times
+
+Model behavior is nondeterministic — the same query might trigger the skill on one run but not the next. Run each query multiple times (3 is a reasonable starting point) and compute a **trigger rate**: the fraction of runs where the skill was invoked.
+
+A should-trigger query passes if its trigger rate is above a threshold (0.5 is a reasonable default). A should-not-trigger query passes if its trigger rate is below that threshold.
+
+With 20 queries at 3 runs each, that's 60 invocations. You'll want to script this. Here's the general structure — replace the `claude` invocation and detection logic in `check_triggered` with whatever your agent client provides:
+
+```bash theme={null}
+#!/bin/bash
+QUERIES_FILE="${1:?Usage: $0 <queries.json>}"
+SKILL_NAME="my-skill"
+RUNS=3
+
+# This example uses Claude Code's JSON output to check for Skill tool calls.
+# Replace this function with detection logic for your agent client.
+# Should return 0 (success) if the skill was invoked, 1 otherwise.
+check_triggered() {
+  local query="$1"
+  claude -p "$query" --output-format json 2>/dev/null \
+    | jq -e --arg skill "$SKILL_NAME" \
+      'any(.messages[].content[]; .type == "tool_use" and .name == "Skill" and .input.skill == $skill)' \
+      > /dev/null 2>&1
+}
+
+count=$(jq length "$QUERIES_FILE")
+for i in $(seq 0 $((count - 1))); do
+  query=$(jq -r ".[$i].query" "$QUERIES_FILE")
+  should_trigger=$(jq -r ".[$i].should_trigger" "$QUERIES_FILE")
+  triggers=0
+
+  for run in $(seq 1 $RUNS); do
+    check_triggered "$query" && triggers=$((triggers + 1))
+  done
+
+  jq -n \
+    --arg query "$query" \
+    --argjson should_trigger "$should_trigger" \
+    --argjson triggers "$triggers" \
+    --argjson runs "$RUNS" \
+    '{query: $query, should_trigger: $should_trigger, triggers: $triggers, runs: $runs, trigger_rate: ($triggers / $runs)}'
+done | jq -s '.'
+```
+
+<Tip>
+  If your agent client supports it, you can stop a run early once the outcome is clear — the agent either consulted the skill or started working without it. This can significantly reduce the time and cost of running the full eval set.
+</Tip>
+
+## Avoiding overfitting with train/validation splits
+
+If you optimize the description against all your queries, you risk overfitting — crafting a description that works for these specific phrasings but fails on new ones.
+
+The solution is to split your query set:
+
+- **Train set (\~60%)**: the queries you use to identify failures and guide improvements.
+- **Validation set (\~40%)**: queries you set aside and only use to check whether improvements generalize.
+
+Make sure both sets contain a proportional mix of should-trigger and should-not-trigger queries — don't accidentally put all the positives in one set. Shuffle randomly and keep the split fixed across iterations so you're comparing apples to apples.
+
+If you're using a script like the one [above](#running-multiple-times), you can split your queries into two files — `train_queries.json` and `validation_queries.json` — and run the script against each one separately.
+
+## The optimization loop
+
+1. **Evaluate** the current description on both _train and validation sets_. The train results guide your changes; the validation results tell you whether those changes are generalizing.
+2. **Identify failures** in the _train set_: which should-trigger queries didn't trigger? Which should-not-trigger queries did?
+   - Only use train set failures to guide your changes — whether you're revising the description yourself or prompting an LLM, keep validation set results out of the process.
+3. **Revise the description.** Focus on generalizing:
+   - If should-trigger queries are failing, the description may be too narrow. Broaden the scope or add context about when the skill is useful.
+   - If should-not-trigger queries are false-triggering, the description may be too broad. Add specificity about what the skill does _not_ do, or clarify the boundary between this skill and adjacent capabilities.
+   - Avoid adding specific keywords from failed queries — that's overfitting. Instead, find the general category or concept those queries represent and address that.
+   - If you're stuck after several iterations, try a structurally different approach to the description rather than incremental tweaks. A different framing or sentence structure may break through where refinement can't.
+   - Check that the description stays under the 1024-character limit — descriptions tend to grow during optimization.
+4. **Repeat** steps 1-3 until all _train set_ queries pass or you stop seeing meaningful improvement.
+5. **Select the best iteration** by its validation pass rate — the fraction of queries in the _validation set_ that passed. Note that the best description may not be the last one you produced; an earlier iteration might have a higher validation pass rate than later ones that overfit to the train set.
+
+Five iterations is usually enough. If performance isn't improving, the issue may be with the queries (too easy, too hard, or poorly labeled) rather than the description.
+
+<Tip>
+  The [`skill-creator`](https://github.com/anthropics/skills/tree/main/skills/skill-creator) Skill automates this loop end-to-end: it splits the eval set, evaluates trigger rates in parallel, proposes description improvements using Claude, and generates a live HTML report you can watch as it runs.
+</Tip>
+
+## Applying the result
+
+Once you've selected the best description:
+
+1. Update the `description` field in your `SKILL.md` frontmatter.
+2. Verify the description is under the [1024-character limit](/specification#description-field).
+3. Verify the description triggers as expected. Try a few prompts manually as a quick sanity check. For a more rigorous test, write 5-10 fresh queries (a mix of should-trigger and should-not-trigger) and run them through the eval script — since these queries were never part of the optimization process, they give you an honest check on whether the description generalizes.
+
+Before and after:
+
+```yaml theme={null}
+# Before
+description: Process CSV files.
+
+# After
+description: >
+  Analyze CSV and tabular data files — compute summary statistics,
+  add derived columns, generate charts, and clean messy data. Use this
+  skill when the user has a CSV, TSV, or Excel file and wants to
+  explore, transform, or visualize the data, even if they don't
+  explicitly mention "CSV" or "analysis."
+```
+
+The improved description is more specific about what the skill does (summary stats, derived columns, charts, cleaning) and broader about when it applies (CSV, TSV, Excel; even without explicit keywords).
+
+## Next steps
+
+Once your skill triggers reliably, you'll want to evaluate whether it produces good outputs. See [Evaluating skill output quality](/skill-creation/evaluating-skills) for how to set up test cases, grade results, and iterate.
+
+Built with [Mintlify](https://mintlify.com).

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "extract:uma-info": "tsx scripts/extract-uma-info.ts",
     "extract:course-data": "tsx scripts/extract-course-data.ts",
     "extract:all": "tsx scripts/extract-all.ts",
+    "course:extract": "tsx scripts/extract-course-entry.ts",
     "skill:compare": "tsx scripts/run-skill-compare.ts",
     "runner:compare": "tsx scripts/run-runner-compare.ts"
   },

--- a/scripts/extract-course-entry.ts
+++ b/scripts/extract-course-entry.ts
@@ -1,0 +1,82 @@
+/**
+ * Extract one course entry from src/modules/data/course_data.json.
+ *
+ * Usage:
+ *   pnpm exec tsx scripts/extract-course-entry.ts --course-id 10914
+ *   pnpm exec tsx scripts/extract-course-entry.ts -c 10914 --compact
+ *   pnpm exec tsx scripts/extract-course-entry.ts -c 10914 --source path/to/course_data.json
+ */
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { Command, InvalidArgumentError } from 'commander';
+
+type CliOptions = {
+  courseId: number;
+  sourcePath: string;
+  compact: boolean;
+};
+
+const DEFAULT_SOURCE_PATH = 'src/modules/data/course_data.json';
+
+function parseCourseId(value: string): number {
+  const courseId = Number.parseInt(value, 10);
+  if (!Number.isInteger(courseId) || courseId <= 0) {
+    throw new InvalidArgumentError(`Invalid course ID: ${value}`);
+  }
+  return courseId;
+}
+
+function parseArgs(argv: Array<string>): CliOptions {
+  // `pnpm run <script> -- ...` can forward a standalone `--` token.
+  const normalizedArgv = argv.filter((arg) => arg !== '--');
+  const program = new Command();
+  program
+    .name('extract-course-entry')
+    .description('Extract one course entry by courseId.')
+    .requiredOption('-c, --course-id <id>', 'Course ID to extract (e.g. 10914)', parseCourseId)
+    .option(
+      '-s, --source <path>',
+      `Path to course_data.json (default: ${DEFAULT_SOURCE_PATH})`,
+      DEFAULT_SOURCE_PATH,
+    )
+    .option('--compact', 'Print compact JSON instead of pretty JSON', false)
+    .showHelpAfterError();
+
+  program.parse(normalizedArgv, { from: 'user' });
+  const options = program.opts<{
+    courseId: number;
+    source: string;
+    compact: boolean;
+  }>();
+
+  return {
+    courseId: options.courseId,
+    sourcePath: options.source,
+    compact: options.compact,
+  };
+}
+
+function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const absolutePath = resolve(options.sourcePath);
+  const raw = readFileSync(absolutePath, 'utf8');
+  const courseData = JSON.parse(raw) as Record<string, unknown>;
+  const key = String(options.courseId);
+  const entry = courseData[key];
+
+  if (!entry) {
+    console.error(`Course ID ${options.courseId} was not found in ${options.sourcePath}`);
+    process.exit(1);
+  }
+
+  const output = {
+    courseId: options.courseId,
+    data: entry,
+  };
+
+  const indent = options.compact ? 0 : 2;
+  console.log(JSON.stringify(output, null, indent));
+}
+
+main();

--- a/src/lib/sunday-tools/skills/parser/conditions/conditions.ts
+++ b/src/lib/sunday-tools/skills/parser/conditions/conditions.ts
@@ -18,6 +18,7 @@
 
 import {
   AllCornerRandomPolicy,
+  CornerRandomPolicy,
   ImmediatePolicy,
   StraightRandomPolicy,
 } from '../../policies/ActivationSamplePolicy';
@@ -223,13 +224,10 @@ export const defaultConditions: ConditionsMap<ICondition> = {
     },
   }),
   corner_count: valueFilter(({ course }) => course.corners.length),
-  // FIXME this shouldn't actually be random, since in cases like corner_random==1@corner_random==2 it should sample
-  // only from the first corner and not from the combined regions, so it needs its own sample policy
-  // actually, that's slightly annoying to handle since corners come in back-to-back pairs, so their regions will
-  // get merged by the union operation.
-  // the real way to fix this is to finally allow placing multiple triggers, then each branch of an @ can simply
-  // place its own trigger and the problem goes away.
   corner_random: random({
+    // Keep this policy distinct from generic RandomPolicy so OrOperator can preserve
+    // branch priority for patterns like corner_random==1@corner_random==2.
+    samplePolicy: CornerRandomPolicy,
     filterEq({ regions, arg: cornerNum, course }: ConditionFilterParams) {
       if (!CourseHelpers.isSortedByStart(course.corners)) {
         throw new Error('course corners must be sorted by start');

--- a/src/lib/sunday-tools/skills/parser/conditions/operators.ts
+++ b/src/lib/sunday-tools/skills/parser/conditions/operators.ts
@@ -2,6 +2,7 @@ import { withDefaultCond } from '../definitions';
 import { kTrue } from './utils';
 import type { RegionList } from '@/lib/sunday-tools/shared/region';
 import type { ActivationSamplePolicy } from '@/lib/sunday-tools/skills/policies/ActivationSamplePolicy';
+import { CornerRandomPolicy } from '@/lib/sunday-tools/skills/policies/ActivationSamplePolicy';
 import type {
   ApplyParams,
   ConditionFilterParams,
@@ -171,9 +172,22 @@ export class OrOperator implements Operator {
     this.samplePolicy = left.samplePolicy.reconcile(right.samplePolicy);
   }
 
-  apply(params: ApplyParams) {
+  apply(params: ApplyParams): [RegionList, DynamicCondition] {
     const [leftval, leftcond] = this.left.apply(params);
     const [rightval, rightcond] = this.right.apply(params);
+
+    // corner_random branches are order-sensitive. For cases like
+    // corner_random==1@corner_random==2, game behavior resolves to the first
+    // satisfiable branch rather than sampling from the union of both corners.
+    if (
+      this.left.samplePolicy === CornerRandomPolicy &&
+      this.right.samplePolicy === CornerRandomPolicy &&
+      leftcond === kTrue &&
+      rightcond === kTrue
+    ) {
+      const branchRegions = leftval.length > 0 ? leftval : rightval;
+      return [branchRegions, kTrue];
+    }
 
     // FIXME this is, technically, completely broken. really the correct way to do this is to tie dynamic conditions to regions
     // and propagate them during union and intersection. however, that's really annoying, and it turns out in practice that
@@ -186,10 +200,7 @@ export class OrOperator implements Operator {
     // unfortunately, there's not really a way here to assert that leftcond and rightcond are the same.
     // this is rather risky. i don't like it.
     // TODO actually, it's perfectly possible to just inspect the tree to make sure the above limitations are satisfied.
-    return [leftval.union(rightval), (s) => leftcond(s) || rightcond(s)] as [
-      RegionList,
-      DynamicCondition,
-    ];
+    return [leftval.union(rightval), (s) => leftcond(s) || rightcond(s)];
   }
 }
 

--- a/src/lib/sunday-tools/skills/policies/ActivationSamplePolicy.ts
+++ b/src/lib/sunday-tools/skills/policies/ActivationSamplePolicy.ts
@@ -79,6 +79,45 @@ export const RandomPolicy = {
   },
 };
 
+/**
+ * Mirrors RandomPolicy sampling, but is distinguishable at parse-time so `@` branches
+ * can preserve corner_random branch priority (first satisfiable branch wins).
+ */
+export const CornerRandomPolicy = {
+  sample(regions: RegionList, nsamples: number, rng: PRNG) {
+    if (regions.length == 0) {
+      return [];
+    }
+    let acc = 0;
+    const weights = regions.map((r) => (acc += r.end - r.start));
+    const samples = [];
+    for (let i = 0; i < nsamples; ++i) {
+      const threshold = rng.uniform(acc);
+      const region = regions.find((_, i) => weights[i] > threshold)!;
+      samples.push(region.start + rng.uniform(region.end - region.start - 10));
+    }
+    return samples.map((pos) => new Region(pos, pos + 10));
+  },
+  reconcile(other: ActivationSamplePolicy) {
+    return other.reconcileRandom(this);
+  },
+  reconcileImmediate(_: ActivationSamplePolicy) {
+    return this;
+  },
+  reconcileDistributionRandom(_other: ActivationSamplePolicy) {
+    return this;
+  },
+  reconcileRandom(other: ActivationSamplePolicy) {
+    return other;
+  },
+  reconcileStraightRandom(other: ActivationSamplePolicy) {
+    return other;
+  },
+  reconcileAllCornerRandom(other: ActivationSamplePolicy) {
+    return other;
+  },
+};
+
 export abstract class DistributionRandomPolicy {
   abstract distribution(upper: number, nsamples: number, rng: PRNG): Array<number>;
 

--- a/src/modules/simulation/simulators/simulators.test.ts
+++ b/src/modules/simulation/simulators/simulators.test.ts
@@ -210,8 +210,10 @@ describe('vacuum-compare simulator', () => {
     });
 
     const mean = result.results.reduce((sum, value) => sum + value, 0) / result.results.length;
-    const meanRunUma1Time = result.runData.meanrun.time[0][result.runData.meanrun.time[0].length - 1];
-    const meanRunUma2Time = result.runData.meanrun.time[1][result.runData.meanrun.time[1].length - 1];
+    const meanRunUma1Time =
+      result.runData.meanrun.time[0][result.runData.meanrun.time[0].length - 1];
+    const meanRunUma2Time =
+      result.runData.meanrun.time[1][result.runData.meanrun.time[1].length - 1];
 
     expect(meanRunUma1Time).toBeLessThan(meanRunUma2Time);
     expect(mean).toBeLessThan(0);
@@ -282,9 +284,7 @@ describe('forced skill positions', () => {
       skills: skillIds,
     });
 
-    const sortedSkills = runner.skills.toSorted(
-      createSkillSorterByGroup(runner.skills),
-    );
+    const sortedSkills = runner.skills.toSorted(createSkillSorterByGroup(runner.skills));
 
     const collector = new BassinCollector();
     const createRunnerObj = toCreateRunner(runner, sortedSkills, forcedPositions);
@@ -316,11 +316,7 @@ describe('forced skill positions', () => {
     });
 
     const forcedPositions = { [TEST_SKILL_ID]: 500 };
-    const createRunnerObj = toCreateRunner(
-      runner,
-      runner.skills,
-      forcedPositions,
-    );
+    const createRunnerObj = toCreateRunner(runner, runner.skills, forcedPositions);
 
     expect(createRunnerObj.forcedPositions).toEqual(forcedPositions);
   });
@@ -343,9 +339,7 @@ describe('forced skill positions', () => {
       strategy: 'Front Runner',
       skills: [skillId],
     });
-    const sortedSkills = runner.skills.toSorted(
-      createSkillSorterByGroup(runner.skills),
-    );
+    const sortedSkills = runner.skills.toSorted(createSkillSorterByGroup(runner.skills));
 
     const withoutForced = toCreateRunner(runner, sortedSkills);
     const withForced = toCreateRunner(runner, sortedSkills, {
@@ -370,9 +364,7 @@ describe('forced skill positions', () => {
       skills: [skillId],
     });
 
-    const sortedSkills = runner.skills.toSorted(
-      createSkillSorterByGroup(runner.skills),
-    );
+    const sortedSkills = runner.skills.toSorted(createSkillSorterByGroup(runner.skills));
 
     const collector = new BassinCollector();
     const race = createInitializedRace({
@@ -401,17 +393,9 @@ describe('forced skill positions', () => {
   it('should activate skill at forced position changing race outcome', () => {
     const skillId = runawaySkillId;
 
-    const withoutForced = runRaceAndCollectActivations(
-      undefined,
-      [skillId],
-      42,
-    );
+    const withoutForced = runRaceAndCollectActivations(undefined, [skillId], 42);
 
-    const withForced = runRaceAndCollectActivations(
-      { [skillId]: 800 },
-      [skillId],
-      42,
-    );
+    const withForced = runRaceAndCollectActivations({ [skillId]: 800 }, [skillId], 42);
 
     expect(withoutForced.createRunnerObj.forcedPositions).toBeUndefined();
     expect(withForced.createRunnerObj.forcedPositions).toEqual({ [skillId]: 800 });
@@ -525,6 +509,76 @@ describe('forced skill positions', () => {
     expect(forcedStarts.every((start) => start === 2000)).toBe(true);
     expect(naturalStarts.some((start) => start !== 2000)).toBe(true);
   });
+
+  it('samples Swinging Maestro trigger from first eligible corner branch', () => {
+    // CM: Pisces Cup
+    const course = CourseHelpers.getCourse(10914); // Hanshin Turf 3200m
+    const racedef = racedefToParams(
+      createRaceConditions({
+        mood: 0, // Not applied
+        ground: 4, // Heavy Conditions
+        weather: 3, // Rainy
+        season: 1, // Spring
+        time: 2, // Daytime
+        grade: 100, // Grade 1 Race
+      }),
+    );
+    const raceParameters = toSundayRaceParameters(racedef);
+    const skillId = '200351'; // Swinging Maestro
+    const baseSeed = 268010; // Seed from reported issue
+
+    const runnerPreset = createRunnerState({
+      outfitId: '100602', // [Ashen Miracle] Oguri Cap
+      speed: 1200,
+      stamina: 1100,
+      power: 1100,
+      guts: 600,
+      wisdom: 1000,
+      strategy: 'Pace Chaser',
+      distanceAptitude: 'S',
+      surfaceAptitude: 'A',
+      strategyAptitude: 'A',
+      mood: 2, // Great Mood
+      skills: ['110061', skillId], // [Festive Miracle, Swinging Maestro]
+      randomMobId: 8123,
+    });
+
+    const sortedSkills = runnerPreset.skills.toSorted(
+      createSkillSorterByGroup(runnerPreset.skills),
+    );
+    const race = createInitializedRace({
+      course,
+      raceParameters,
+      settings: createCompareSettings(),
+      duelingRates: DEFAULT_DUELING_RATES,
+      skillSamples: 1,
+      runner: toCreateRunner(runnerPreset, sortedSkills),
+    });
+
+    const starts: Array<number> = [];
+    for (let i = 0; i < 120; i++) {
+      race.prepareRound(baseSeed + i);
+      const raceRunner = race.runners.values().toArray()[0];
+      const pendingForSkill = raceRunner.pendingSkills.filter(
+        (ps) => ps.skillId === skillId || ps.skillId.startsWith(skillId),
+      );
+      expect(pendingForSkill).toHaveLength(1);
+      starts.push(pendingForSkill[0].trigger.start);
+    }
+
+    const buckets = { c1: 0, c2: 0, c3: 0, c4: 0, other: 0 };
+    for (const start of starts) {
+      if (start >= 1520 && start < 1710) buckets.c1++;
+      else if (start >= 1710 && start < 1900) buckets.c2++;
+      else if (start >= 2250 && start < 2550) buckets.c3++;
+      else if (start >= 2550 && start < 2850) buckets.c4++;
+      else buckets.other++;
+    }
+
+    expect(buckets.c2 + buckets.c3 + buckets.c4 + buckets.other).toBe(0);
+    expect(buckets.c1).toBe(starts.length);
+    expect(new Set(starts).size).toBeGreaterThan(1);
+  });
 });
 
 describe('injected debuffs', () => {
@@ -537,7 +591,12 @@ describe('injected debuffs', () => {
     });
 
     const injectedDebuffs = [{ skillId: TEST_DEBUFF_SKILL_ID, position: 700 }];
-    const createRunnerObj = (toCreateRunner as any)(runner, runner.skills, undefined, injectedDebuffs);
+    const createRunnerObj = (toCreateRunner as any)(
+      runner,
+      runner.skills,
+      undefined,
+      injectedDebuffs,
+    );
 
     expect(createRunnerObj.injectedDebuffs).toEqual(injectedDebuffs);
   });
@@ -623,8 +682,10 @@ describe('injected debuffs', () => {
       },
     } as any);
 
-    const meanWithout = withoutDebuff.results.reduce((sum, value) => sum + value, 0) / withoutDebuff.results.length;
-    const meanWith = withDebuff.results.reduce((sum, value) => sum + value, 0) / withDebuff.results.length;
+    const meanWithout =
+      withoutDebuff.results.reduce((sum, value) => sum + value, 0) / withoutDebuff.results.length;
+    const meanWith =
+      withDebuff.results.reduce((sum, value) => sum + value, 0) / withDebuff.results.length;
 
     expect(meanWith).toBeGreaterThan(meanWithout);
   });


### PR DESCRIPTION
## Summary

This PR fixes a regression in `Swinging Maestro` (`200351`) trigger sampling where OR-branch flattening caused activations to be sampled from later corners instead of the first eligible corner branch.

### Findings

- Reproduced on course `10914` with condition:
  - `corner_random==1@corner_random==2@corner_random==3@corner_random==4`
- Root cause:
  - `corner_random` used generic random sampling semantics.
  - `OrOperator` unions branch regions, which collapses branch order and can sample from later corner branches.
- Impact:
  - Trigger starts leaked into later corner buckets, matching the reported late-proc behavior.

### Quick Fix

- Added a distinct `CornerRandomPolicy` so `corner_random` branches can be identified/reconciled separately from generic random conditions.
- Updated `corner_random` condition to use `CornerRandomPolicy`.
- Tightened `OrOperator.apply()` typing and added corner-specific branch-priority behavior:
  - when both sides are static `CornerRandomPolicy` branches, use first satisfiable branch regions (`left` if non-empty, otherwise `right`) instead of unioning.
- Preserves existing behavior for non-corner OR conditions.

### Regression Coverage

- Added/tightened simulator regression:
  - `samples Swinging Maestro trigger from first eligible corner branch`
- Coverage asserts:
  - one pending trigger candidate per round for the skill
  - starts remain exclusively in first eligible corner bucket (`c1`)
  - no starts in `c2/c3/c4/other`
  - randomness remains within selected branch (not collapsed to a single position)

### Long-Term Fix (follow-up)

This PR is intentionally a targeted stabilization. The general solution is branch-aware condition handling end-to-end:

1. Parser returns ordered OR branches (region + dynamic condition + policy), instead of flattening to one tuple.
2. `&` distributes across branches; `@` preserves branch order instead of unioning regions.
3. Runner resolves branches at runtime in order, activating the first satisfied branch and retiring siblings.
4. Remove the corner-specific OR workaround once branch-aware trigger resolution is in place.

This broader refactor solves mixed static/dynamic OR correctness beyond `corner_random`.

## Validation

```bash
pnpm exec vitest run src/modules/simulation/simulators/simulators.test.ts -t "samples Swinging Maestro trigger from first eligible corner branch"
```

## Supporting Artifacts

- Investigation report and reproduction notes were added/updated.
- Added `course:extract` helper script for quick course geometry extraction used during debugging/verification.
 
[maestro-proc-investigation.md](https://github.com/user-attachments/files/25996332/maestro-proc-investigation.md)
