### PR TITLE
feat(carat): add multi-pickup copy goals

### DIFF
--- a/src/modules/carat/components/carat-calculator-page.tsx
+++ b/src/modules/carat/components/carat-calculator-page.tsx
@@ -46,6 +46,7 @@ export function CaratCalculatorPage() {
   }, [isActive, tutorialId]);
 
   const startTour = () => {
+    setActiveTab('calculator');
     setIsFirstVisitNudgeOpen(false);
     start('carat-calculator', caratCalculatorSteps);
   };

--- a/src/modules/carat/components/carat-calculator-page.tsx
+++ b/src/modules/carat/components/carat-calculator-page.tsx
@@ -103,6 +103,11 @@ export function CaratCalculatorPage() {
         </div>
       ) : null}
 
+      <p className="mb-4 text-[11px] leading-relaxed text-muted-foreground">
+        Estimates only. Odds use independent-probability models and are not guarantees — your actual
+        results will vary. This is not financial advice; only spend what you can comfortably afford.
+      </p>
+
       <SummaryStats />
 
       <div className="grid items-start gap-4 lg:grid-cols-[330px_1fr]">

--- a/src/modules/carat/components/copies-odds-bar.tsx
+++ b/src/modules/carat/components/copies-odds-bar.tsx
@@ -5,6 +5,7 @@ import { cn } from '@/lib/utils';
 export type CopiesOddsBarProps = {
   pulls: number;
   startingDupes?: number;
+  pickupCount?: number;
   odds?: CopiesOdds;
   className?: string;
 };
@@ -34,11 +35,13 @@ export function CopiesOddsBar(props: CopiesOddsBarProps) {
   const {
     pulls,
     startingDupes = 0,
+    pickupCount = 1,
     odds = copiesOdds({ pulls, startingDupes }),
     className
   } = props;
   const atLeastOne = 1 - odds.none;
   const sparkReached = pulls >= PITY_PULLS;
+  const multiPickup = pickupCount > 1;
 
   return (
     <div className={cn('min-w-[180px] space-y-1.5', className)}>
@@ -76,6 +79,12 @@ export function CopiesOddsBar(props: CopiesOddsBarProps) {
       <div className="text-[11px] text-muted-foreground">
         {sparkReached ? 'Spark reached' : `${Math.max(0, PITY_PULLS - pulls)} pulls to spark`}
       </div>
+      {multiPickup ? (
+        <div className="text-[11px] leading-snug text-muted-foreground">
+          Bar is for <span className="font-medium text-foreground">one</span> targeted card. Use
+          Goals to plan for {pickupCount} rate-up SSRs with different copy targets.
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/src/modules/carat/components/sortable-plan-card.tsx
+++ b/src/modules/carat/components/sortable-plan-card.tsx
@@ -9,7 +9,12 @@ import { InfoHint } from '@/modules/carat/components/info-hint';
 import { PlanDragHandle } from '@/modules/carat/components/plan-drag-handle';
 import { PullsField } from '@/modules/carat/components/pulls-field';
 import { RemovePlannedBannerButton } from '@/modules/carat/components/remove-planned-banner-button';
-import { characterPickupCount, resolveBannerLabel } from '@/modules/carat/data/card-names';
+import {
+  characterPickupCount,
+  resolveBannerLabel,
+  supportPickupCount
+} from '@/modules/carat/data/card-names';
+import { TargetGoals } from '@/modules/carat/components/target-goals';
 import type { BannerPlanRow } from '@/modules/carat/model/plan';
 import { cn } from '@/lib/utils';
 
@@ -85,9 +90,11 @@ export function SortablePlanCard(props: SortablePlanCardProps) {
           <CopiesOddsBar
             pulls={row.plannedBanner.plannedPulls}
             startingDupes={row.plannedBanner.startingDupes}
+            pickupCount={supportPickupCount(row.event)}
             className="min-w-0"
           />
         )}
+        <TargetGoals row={row} className="mt-2" />
       </div>
     </div>
   );

--- a/src/modules/carat/components/sortable-plan-row.tsx
+++ b/src/modules/carat/components/sortable-plan-row.tsx
@@ -8,7 +8,12 @@ import { UmaOddsBar } from '@/modules/carat/components/uma-odds-bar';
 import { PlanDragHandle } from '@/modules/carat/components/plan-drag-handle';
 import { PullsField } from '@/modules/carat/components/pulls-field';
 import { RemovePlannedBannerButton } from '@/modules/carat/components/remove-planned-banner-button';
-import { characterPickupCount, resolveBannerLabel } from '@/modules/carat/data/card-names';
+import {
+  characterPickupCount,
+  resolveBannerLabel,
+  supportPickupCount
+} from '@/modules/carat/data/card-names';
+import { TargetGoals } from '@/modules/carat/components/target-goals';
 import type { BannerPlanRow } from '@/modules/carat/model/plan';
 import { cn } from '@/lib/utils';
 
@@ -67,8 +72,10 @@ export function SortablePlanRow(props: SortablePlanRowProps) {
           <CopiesOddsBar
             pulls={row.plannedBanner.plannedPulls}
             startingDupes={row.plannedBanner.startingDupes}
+            pickupCount={supportPickupCount(row.event)}
           />
         )}
+        <TargetGoals row={row} className="mt-2" />
       </td>
       <td className="w-10 px-2 py-3 text-right">
         <RemovePlannedBannerButton bannerId={row.event.id} bannerLabel={bannerLabel} />

--- a/src/modules/carat/components/target-goals.tsx
+++ b/src/modules/carat/components/target-goals.tsx
@@ -1,0 +1,185 @@
+import { TargetIcon } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from '@/components/ui/select';
+import { bannerPickupTargets } from '@/modules/carat/data/card-names';
+import type { BannerPlanRow } from '@/modules/carat/model/plan';
+import { PITY_PULLS, targetGoalsOdds } from '@/modules/carat/model/odds';
+import { setCopyGoal, setOwnedCopies } from '@/store/carat.store';
+import { cn } from '@/lib/utils';
+
+type TargetGoalsProps = {
+  row: BannerPlanRow;
+  className?: string;
+};
+
+// Copy goal options. 1 copy = LB0 (base), 5 copies = MLB, matching the
+// CopiesOddsBar tier labels.
+const GOAL_OPTIONS: { value: number; label: string }[] = [
+  { value: 0, label: 'Skip' },
+  { value: 1, label: '1 (LB0)' },
+  { value: 2, label: '2 (LB1)' },
+  { value: 3, label: '3 (LB2)' },
+  { value: 4, label: '4 (LB3)' },
+  { value: 5, label: '5 (MLB)' }
+];
+
+// Copies already owned (reruns). Capped at 4 — owning MLB leaves nothing to pull.
+const OWNED_OPTIONS: { value: number; label: string }[] = [
+  { value: 0, label: 'None' },
+  { value: 1, label: '1 (LB0)' },
+  { value: 2, label: '2 (LB1)' },
+  { value: 3, label: '3 (LB2)' },
+  { value: 4, label: '4 (LB3)' }
+];
+
+const GOAL_SHORT: Record<number, string> = {
+  1: 'LB0',
+  2: 'LB1',
+  3: 'LB2',
+  4: 'LB3',
+  5: 'MLB'
+};
+
+function shortName(name: string) {
+  return name.split(']').pop()?.trim() || name;
+}
+
+function formatPercent(value: number, maximumFractionDigits = 1) {
+  return new Intl.NumberFormat(undefined, { style: 'percent', maximumFractionDigits }).format(
+    value
+  );
+}
+
+export function TargetGoals(props: TargetGoalsProps) {
+  const { row, className } = props;
+  const targets = bannerPickupTargets(row.event);
+  if (targets.length < 2) return null;
+
+  const goals = row.plannedBanner.copyGoals ?? {};
+  const owned = row.plannedBanner.ownedCopies ?? {};
+  const pulls = row.plannedBanner.plannedPulls;
+
+  // Each active goal contributes the copies the banner still needs to supply:
+  // total goal minus copies already owned.
+  const activeGoals = targets
+    .map((target) => {
+      const goal = goals[target.id] ?? 0;
+      const have = Math.min(owned[target.id] ?? 0, Math.max(0, goal));
+      return { target, goal, have, needed: Math.max(0, goal - have) };
+    })
+    .filter((entry) => entry.goal >= 1);
+  const hasGoals = activeGoals.length > 0;
+
+  const chance = hasGoals
+    ? targetGoalsOdds({ pulls, goals: activeGoals.map((entry) => entry.needed) })
+    : null;
+  const sparks = Math.floor(pulls / PITY_PULLS);
+  const neededSparks = activeGoals.reduce((total, entry) => total + entry.needed, 0);
+
+  return (
+    <div className={cn('space-y-1.5', className)}>
+      <Popover>
+        <PopoverTrigger
+          render={
+            <Button type="button" variant="outline" size="xs" className="gap-1.5">
+              <TargetIcon />
+              {hasGoals ? `Goals · ${activeGoals.length}` : 'Set goals'}
+            </Button>
+          }
+        />
+        <PopoverContent align="start" className="w-96">
+          <div className="flex items-center justify-between gap-2 text-[11px] font-medium text-muted-foreground">
+            <span className="flex-1">Card</span>
+            <span className="w-24 text-center">Own</span>
+            <span className="w-24 text-center">Goal</span>
+          </div>
+          <div className="space-y-1.5">
+            {targets.map((target) => {
+              const goalValue = goals[target.id] ?? 0;
+              const ownValue = owned[target.id] ?? 0;
+              return (
+                <div key={target.id} className="flex items-center justify-between gap-2">
+                  <span className="min-w-0 flex-1 truncate text-xs" title={target.name}>
+                    {target.name}
+                  </span>
+                  <Select
+                    value={String(ownValue)}
+                    onValueChange={(next) =>
+                      next != null && setOwnedCopies(row.event.id, target.id, Number(next))
+                    }
+                  >
+                    <SelectTrigger
+                      size="sm"
+                      aria-label={`Copies already owned of ${target.name}`}
+                      className="h-7 w-24 shrink-0"
+                    >
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {OWNED_OPTIONS.map((option) => (
+                        <SelectItem key={option.value} value={String(option.value)}>
+                          {option.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <Select
+                    value={String(goalValue)}
+                    onValueChange={(next) =>
+                      next != null && setCopyGoal(row.event.id, target.id, Number(next))
+                    }
+                  >
+                    <SelectTrigger
+                      size="sm"
+                      aria-label={`Copy goal for ${target.name}`}
+                      className="h-7 w-24 shrink-0"
+                    >
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {GOAL_OPTIONS.map((option) => (
+                        <SelectItem key={option.value} value={String(option.value)}>
+                          {option.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+              );
+            })}
+          </div>
+          <p className="text-[11px] leading-snug text-muted-foreground">
+            Own = copies you already have (reruns). Each {PITY_PULLS}-pull spark guarantees one copy
+            of one card, allocated to your hardest goals first.
+          </p>
+        </PopoverContent>
+      </Popover>
+
+      {hasGoals && chance != null ? (
+        <div className="space-y-0.5 text-[11px] leading-snug text-muted-foreground">
+          <div>
+            <span className="font-mono font-semibold text-foreground tabular-nums">
+              {formatPercent(chance)}
+            </span>{' '}
+            to reach{' '}
+            {activeGoals
+              .map((entry) => `${GOAL_SHORT[entry.goal]} ${shortName(entry.target.name)}`)
+              .join(' + ')}
+            .
+          </div>
+          <div>
+            Banner must supply {neededSparks} cop{neededSparks === 1 ? 'y' : 'ies'} worst-case;{' '}
+            {sparks} spark{sparks === 1 ? '' : 's'} at {pulls} pulls.
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/src/modules/carat/components/uma-odds-bar.tsx
+++ b/src/modules/carat/components/uma-odds-bar.tsx
@@ -16,7 +16,7 @@ export function UmaOddsBar(props: UmaOddsBarProps) {
   const { pickupCount = 1, className } = props;
 
   const chance = umaOutcomeOdds(pickupCount).rateUp;
-  const target = pickupCount > 1 ? 'a rate-up Uma' : 'the rate-up Uma';
+  const target = pickupCount > 1 ? `any one of ${pickupCount} rate-up Umas` : 'the rate-up Uma';
 
   return (
     <p className={cn('min-w-[180px] text-xs leading-snug text-muted-foreground', className)}>

--- a/src/modules/carat/data/card-names.ts
+++ b/src/modules/carat/data/card-names.ts
@@ -1,4 +1,5 @@
 import characterCards from '@/modules/data/json/gametora/character-cards.json';
+import supportCards from '@/modules/data/json/gametora/support-cards.json';
 import type { TimelineEvent } from './timeline-types';
 
 type CharacterCardRecord = {
@@ -28,6 +29,57 @@ export function characterPickupCount(event: TimelineEvent): number {
     (cardId) => characterCardNameMap.get(cardId)?.rarity === 3
   ).length;
   return Math.max(1, count);
+}
+
+type SupportCardRecord = {
+  support_id: number;
+  rarity: number;
+  char_name: string;
+  title_en?: string;
+};
+
+const supportCardMap = new Map<number, SupportCardRecord>(
+  (supportCards as SupportCardRecord[]).map((card) => [card.support_id, card])
+);
+
+// Counts the rate-up (pickup) SSR support cards on a banner. Each rate-up SSR
+// keeps its own 0.75% pull rate regardless of count, but the 200-pull spark
+// only guarantees one copy of one card, so multi-pickup banners need a caveat.
+export function supportPickupCount(event: TimelineEvent): number {
+  const count = (event.pickup_card_ids ?? []).filter(
+    (cardId) => supportCardMap.get(cardId)?.rarity === 3
+  ).length;
+  return Math.max(1, count);
+}
+
+export type PickupTarget = {
+  id: number;
+  name: string;
+};
+
+// The list of 3-star rate-up cards/Umas a player can set copy goals for,
+// preserving banner order. Returns support SSRs for support banners and 3-star
+// Umas for character banners.
+export function bannerPickupTargets(event: TimelineEvent): PickupTarget[] {
+  const ids = event.pickup_card_ids ?? [];
+
+  if (event.card_type === 'character') {
+    return ids
+      .map((id) => {
+        const card = characterCardNameMap.get(id);
+        return card?.rarity === 3 ? { id, name: card.name_en } : null;
+      })
+      .filter((target): target is PickupTarget => target !== null);
+  }
+
+  return ids
+    .map((id) => {
+      const card = supportCardMap.get(id);
+      if (card?.rarity !== 3) return null;
+      const name = card.title_en ? `${card.title_en} ${card.char_name}` : card.char_name;
+      return { id, name };
+    })
+    .filter((target): target is PickupTarget => target !== null);
 }
 
 export function resolveBannerLabel(event: TimelineEvent): string {

--- a/src/modules/carat/model/odds.test.ts
+++ b/src/modules/carat/model/odds.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest';
-import { binomPmf, copiesOdds, RATEUP_P, type CopiesOdds } from '@/modules/carat/model/odds';
+import {
+  binomPmf,
+  copiesOdds,
+  RATEUP_P,
+  targetGoalsOdds,
+  type CopiesOdds
+} from '@/modules/carat/model/odds';
 
 const REFERENCE: Array<{ pulls: number; odds: CopiesOdds }> = [
   { pulls: 0, odds: { none: 1, lb0: 0, lb1: 0, lb2: 0, lb3: 0, mlb: 0 } },
@@ -31,6 +37,43 @@ describe('binomial odds', () => {
           0.005
         );
       }
+    }
+  });
+
+  it('matches single-card ≥1-copy odds for one goal', () => {
+    // No spark: one goal of 1 copy = 1 - (1-p)^pulls.
+    const single = 1 - copiesOdds({ pulls: 100 }).none;
+    expect(targetGoalsOdds({ pulls: 100, goals: [1] })).toBeCloseTo(single, 8);
+    // Spark guarantees the single 1-copy goal outright.
+    expect(targetGoalsOdds({ pulls: 200, goals: [1] })).toBe(1);
+    // Empty goals are always satisfied.
+    expect(targetGoalsOdds({ pulls: 0, goals: [] })).toBe(1);
+  });
+
+  it('only fails when the spark cannot cover the shortfall', () => {
+    // Two 1-copy goals at 200 pulls = 1 spark. You fail only if BOTH cards whiff
+    // their random pulls, since one spark covers a single miss.
+    const bothMiss = Math.pow(1 - RATEUP_P, 400);
+    expect(targetGoalsOdds({ pulls: 200, goals: [1, 1] })).toBeCloseTo(1 - bothMiss, 6);
+  });
+
+  it('matches a single MLB goal against copiesOdds.mlb', () => {
+    // One 5-copy (MLB) goal must equal the single-card MLB odds.
+    expect(targetGoalsOdds({ pulls: 200, goals: [5] })).toBeCloseTo(copiesOdds({ pulls: 200 }).mlb, 6);
+  });
+
+  it('drops far below 100% for MLB + LB0 on a 2-SSR banner with 400 pulls', () => {
+    // The misleading case: 400 pulls = 2 sparks, but MLB needs 5 copies, so this
+    // is nowhere near guaranteed.
+    const chance = targetGoalsOdds({ pulls: 400, goals: [5, 1] });
+    expect(chance).toBeGreaterThan(0);
+    expect(chance).toBeLessThan(0.6);
+  });
+
+  it('is harder for higher copy goals', () => {
+    const values = [1, 2, 3, 4, 5].map((goal) => targetGoalsOdds({ pulls: 300, goals: [goal, 1] }));
+    for (let index = 1; index < values.length; index += 1) {
+      expect(values[index]).toBeLessThanOrEqual(values[index - 1]);
     }
   });
 

--- a/src/modules/carat/model/odds.ts
+++ b/src/modules/carat/model/odds.ts
@@ -82,6 +82,7 @@ export function binomPmf(k: number, n: number, p: number): number {
   return binomDist(k, n, p, false);
 }
 
+
 export function binomCdf(k: number, n: number, p: number): number {
   return binomDist(k, n, p, true);
 }
@@ -92,7 +93,11 @@ function tierPmf(totalCopies: number, guaranteed: number, pulls: number, p: numb
 
 // Confirmed by the live gacha_odds endpoint: total 3-star rate on a character
 // banner is 3%, each rate-up (pickup) Uma is 0.75%, and the remainder is split
-// across the off-banner 3-star pool.
+// across the off-banner 3-star pool. The same flat 0.75% holds per rate-up SSR
+// support card and does NOT divide on multi-pickup banners (verified against the
+// 2-SSR Maruzensky/Nakayama and 4th Anniv 2-SSR banners), so per-target copy
+// odds are correct as-is; multi-pickup banners only need a labeling caveat that
+// the spark guarantees a single copy of a single card.
 export const TOTAL_3STAR_P = 0.03;
 // "Less than 200 pulls" excludes the guaranteed spark at pull 200.
 export const SUB_SPARK_PULLS = PITY_PULLS - 1;
@@ -124,6 +129,60 @@ export function umaOutcomeOdds(pickupCount = 1, pulls: number = SUB_SPARK_PULLS)
     offBannerOnly: Math.max(0, noRateUp - nothing),
     nothing
   };
+}
+
+export type TargetGoalsInput = {
+  pulls: number;
+  // Desired total copies per targeted card (1..MLB_COPIES). Cards with goal 0
+  // are ignored. Each rate-up shares the same per-pull rate `p`.
+  goals: number[];
+  p?: number;
+  mode?: CopiesOddsMode;
+};
+
+// Probability of meeting every per-card copy goal at once. Random copies for
+// each card are independent Binomial(pulls, p) (the combined rate-up rate stays
+// below ~6%, so multinomial correlation is negligible). Pity sparks are
+// guaranteed exchanges allocated optimally to cover shortfalls, so success is
+// exactly: total shortfall = Σ max(0, goal_i - randomCopies_i) ≤ sparks. We build
+// each card's shortfall distribution and convolve them, then sum P(total ≤ sparks).
+export function targetGoalsOdds(input: TargetGoalsInput): number {
+  const mode = input.mode ?? 'standard';
+  const p = input.p ?? (mode === 'stepup' ? STEPUP_SLOT_P : RATEUP_P);
+  const pulls = normalizeCount(input.pulls);
+  const goals = input.goals
+    .map((goal) => Math.min(MLB_COPIES, normalizeCount(goal)))
+    .filter((goal) => goal >= 1);
+  if (goals.length === 0) return 1;
+
+  const sparkAt = mode === 'stepup' ? 5 : PITY_PULLS;
+  const randomPulls = mode === 'stepup' ? pulls * 10 : pulls;
+  const sparks = Math.floor(pulls / sparkAt);
+
+  // dist[s] = probability that the running total shortfall equals s.
+  let dist = [1];
+  for (const goal of goals) {
+    const shortfall: number[] = Array.from({ length: goal + 1 }, () => 0);
+    // shortfall 0 means the card already has >= goal random copies.
+    shortfall[0] = 1 - binomCdf(goal - 1, randomPulls, p);
+    for (let missing = 1; missing <= goal; missing += 1) {
+      shortfall[missing] = binomPmf(goal - missing, randomPulls, p);
+    }
+
+    const next: number[] = Array.from({ length: dist.length + goal }, () => 0);
+    for (let a = 0; a < dist.length; a += 1) {
+      for (let missing = 0; missing <= goal; missing += 1) {
+        next[a + missing] += dist[a] * shortfall[missing];
+      }
+    }
+    dist = next;
+  }
+
+  let total = 0;
+  for (let s = 0; s <= Math.min(sparks, dist.length - 1); s += 1) {
+    total += dist[s];
+  }
+  return Math.min(1, Math.max(0, total));
 }
 
 export function copiesOdds(input: CopiesOddsInput): CopiesOdds {

--- a/src/modules/carat/model/plan.test.ts
+++ b/src/modules/carat/model/plan.test.ts
@@ -47,8 +47,8 @@ describe('computePlan', () => {
     const early = banner('early', 1);
     const late = banner('late', 40);
     const plan: PlannedBanner[] = [
-      { id: 'late', plannedPulls: 0, startingDupes: 0, order: 0 },
-      { id: 'early', plannedPulls: 100, startingDupes: 0, order: 1 }
+      { id: 'late', plannedPulls: 0, startingDupes: 0, copyGoals: {}, ownedCopies: {}, order: 0 },
+      { id: 'early', plannedPulls: 100, startingDupes: 0, copyGoals: {}, ownedCopies: {}, order: 1 }
     ];
 
     const rows = computePlan(settings, timeline([late, early]), plan);
@@ -64,8 +64,8 @@ describe('computePlan', () => {
 
   it('ignores planned banners that are not present in the timeline', () => {
     const rows = computePlan(settings, timeline([banner('real', 5)]), [
-      { id: 'example-banner', plannedPulls: 200, startingDupes: 0, order: 0 },
-      { id: 'real', plannedPulls: 1, startingDupes: 0, order: 1 }
+      { id: 'example-banner', plannedPulls: 200, startingDupes: 0, copyGoals: {}, ownedCopies: {}, order: 0 },
+      { id: 'real', plannedPulls: 1, startingDupes: 0, copyGoals: {}, ownedCopies: {}, order: 1 }
     ]);
 
     expect(rows).toHaveLength(1);
@@ -77,7 +77,7 @@ describe('computePlan', () => {
     const rows = computePlan(
       { ...settings, trackPaidCarats: true, startingPaidCarats: 1500 },
       timeline([banner('paid', 1)]),
-      [{ id: 'paid', plannedPulls: 20, startingDupes: 0, order: 0 }],
+      [{ id: 'paid', plannedPulls: 20, startingDupes: 0, copyGoals: {}, ownedCopies: {}, order: 0 }],
       { '1st-anniversary': { p1500: 1 } }
     );
 

--- a/src/store/carat.store.ts
+++ b/src/store/carat.store.ts
@@ -28,6 +28,12 @@ export type PlannedBanner = {
   id: string;
   plannedPulls: number;
   startingDupes: number;
+  // Desired total copies per rate-up card, keyed by pickup card id. Absent or 0
+  // means "not targeted". Empty object falls back to the single-card odds view.
+  copyGoals: Record<string, number>;
+  // Copies the player already owns per rate-up card (reruns), keyed by pickup
+  // card id. These reduce how many copies the banner needs to supply.
+  ownedCopies: Record<string, number>;
   order: number;
 };
 
@@ -68,6 +74,8 @@ export const defaultPlannedBanners: PlannedBanner[] = [
     id: 'example-banner',
     plannedPulls: 200,
     startingDupes: 0,
+    copyGoals: {},
+    ownedCopies: {},
     order: 0
   }
 ];
@@ -89,7 +97,11 @@ export const useCaratStore = create<CaratStore>()(
         ...current,
         ...state,
         settings: { ...defaultCaratSettings, ...state.settings },
-        plannedBanners: state.plannedBanners ?? defaultPlannedBanners,
+        plannedBanners: (state.plannedBanners ?? defaultPlannedBanners).map((banner) => ({
+          ...banner,
+          copyGoals: banner.copyGoals ?? {},
+          ownedCopies: banner.ownedCopies ?? {}
+        })),
         paidPurchases: state.paidPurchases ?? {},
         selectorChoices: state.selectorChoices ?? {}
       };
@@ -130,6 +142,8 @@ export function addPlannedBanner(id: string) {
           id,
           plannedPulls: 0,
           startingDupes: 0,
+          copyGoals: {},
+          ownedCopies: {},
           order: nextOrder
         }
       ]
@@ -160,6 +174,38 @@ export function setPlannedPulls(id: string, plannedPulls: number) {
     plannedBanners: state.plannedBanners.map((banner) =>
       banner.id === id ? { ...banner, plannedPulls } : banner
     )
+  }));
+}
+
+export function setCopyGoal(bannerId: string, cardId: number, copies: number) {
+  useCaratStore.setState((state) => ({
+    plannedBanners: state.plannedBanners.map((banner) => {
+      if (banner.id !== bannerId) return banner;
+      const nextGoals = { ...banner.copyGoals };
+      const value = Math.max(0, Math.min(5, Math.floor(copies || 0)));
+      if (value <= 0) {
+        delete nextGoals[cardId];
+      } else {
+        nextGoals[cardId] = value;
+      }
+      return { ...banner, copyGoals: nextGoals };
+    })
+  }));
+}
+
+export function setOwnedCopies(bannerId: string, cardId: number, copies: number) {
+  useCaratStore.setState((state) => ({
+    plannedBanners: state.plannedBanners.map((banner) => {
+      if (banner.id !== bannerId) return banner;
+      const nextOwned = { ...banner.ownedCopies };
+      const value = Math.max(0, Math.min(4, Math.floor(copies || 0)));
+      if (value <= 0) {
+        delete nextOwned[cardId];
+      } else {
+        nextOwned[cardId] = value;
+      }
+      return { ...banner, ownedCopies: nextOwned };
+    })
   }));
 }
 


### PR DESCRIPTION
Adds per-card copy goals for multi-pickup banners so planning can express real wants like “MLB Light Hello, 1LB Tachyon” instead of treating every target as “at least one copy.” Also adds a visible odds/financial-advice disclaimer and fixes the tutorial starting from the Selector tab.

## Goal odds flow
```mermaid
flowchart LR
  A["Rate-up pickups"] --> B["Set goals popover"]
  B --> C["Own copies + desired goal"]
  C --> D["Needed copies from banner"]
  D --> E["Shortfall distributions"]
  E --> F["Convolve total shortfall"]
  F --> G{"shortfall ≤ sparks?"}
  G --> H["Combined chance to reach all goals"]
```

## What's here
- **target-goals.tsx** — compact Goals popover for multi-pickup banners with per-card Own and Goal selectors.
- **odds.ts** — `targetGoalsOdds`, using shortfall convolution and optimal spark allocation.
- **card-names.ts** — resolves named SSR/3-star pickup targets for support and Uma banners.
- **carat.store.ts** — persists per-banner copy goals and owned copies.
- **copies/uma odds bars** — keep single-target odds visible; multi-pickup caveat points users to Goals.
- **carat-calculator-page.tsx** — visible estimate/not-financial-advice notice and tutorial tab fix.

## Gates
- `bun run typecheck` ✅
- `bun run test` ✅ — 54 files passed, 1 skipped; 281 tests passed, 8 skipped
- ESLint on changed files ✅

## Caveats
- Owned copies are manual and scoped to the planned banner, not a global collection tracker.
- Goal odds model random copies independently per target, then allocates sparks optimally across remaining shortfalls.
- Crystal/pack-value modeling is intentionally out of scope; the disclaimer covers spending-risk framing.
