### PR TITLE
feat(carat): type-aware ticket pools + per-banner ticket slot

### DIFF
--- a/src/modules/carat/components/banner-plan-table.tsx
+++ b/src/modules/carat/components/banner-plan-table.tsx
@@ -123,6 +123,7 @@ export function BannerPlanTable(props: BannerPlanTableProps) {
                         </InfoHint>
                       </span>
                     </th>
+                    <th className="w-44 min-w-44 px-2 py-2 text-left">Tickets</th>
                     {showPaid ? <th className="px-2 py-2 text-right">Paid pool</th> : null}
                     <th className="px-2 py-2 text-right">Balance</th>
                     <th className="px-2 py-2 text-center">

--- a/src/modules/carat/components/income-settings.tsx
+++ b/src/modules/carat/components/income-settings.tsx
@@ -82,7 +82,7 @@ function NumberField(props: {
         inputMode="numeric"
         min={0}
         value={value}
-        onChange={(event) => setCaratSetting(settingKey, Number(event.target.value) || 0)}
+        onChange={(event) => setCaratSetting(settingKey, Math.max(0, Number(event.target.value) || 0))}
         className="text-right tabular-nums"
       />
     </label>

--- a/src/modules/carat/components/pulls-field.tsx
+++ b/src/modules/carat/components/pulls-field.tsx
@@ -25,6 +25,12 @@ export function PullsField(props: PullsFieldProps) {
   const costLine = showCost ? (
     <div className="font-mono text-[11px] text-muted-foreground tabular-nums">
       Cost {formatCarats(row.cost)}
+      {row.ticketsUsed > 0 ? (
+        <span className="text-emerald-600 dark:text-emerald-400">
+          {' '}
+          (−{row.ticketsUsed.toLocaleString()} tix)
+        </span>
+      ) : null}
       {row.paidCost > 0 ? ` · paid ${formatCarats(row.paidCost)}` : ''}
     </div>
   ) : null;

--- a/src/modules/carat/components/sortable-plan-card.tsx
+++ b/src/modules/carat/components/sortable-plan-card.tsx
@@ -8,6 +8,7 @@ import { UmaOddsBar } from '@/modules/carat/components/uma-odds-bar';
 import { InfoHint } from '@/modules/carat/components/info-hint';
 import { PlanDragHandle } from '@/modules/carat/components/plan-drag-handle';
 import { PullsField } from '@/modules/carat/components/pulls-field';
+import { TicketsField } from '@/modules/carat/components/tickets-field';
 import { RemovePlannedBannerButton } from '@/modules/carat/components/remove-planned-banner-button';
 import {
   characterPickupCount,
@@ -49,22 +50,31 @@ export function SortablePlanCard(props: SortablePlanCardProps) {
       </div>
 
       <div className="mt-3 grid grid-cols-2 gap-3">
-        <div className="grid gap-1 text-xs text-muted-foreground">
-          <span className="inline-flex items-center gap-1">
-            Pulls
-            <InfoHint label="Pulls and sparks help" title="Pulls and sparks">
-              One pull costs 150 carats. One spark is 200 pulls and can be exchanged for a
-              guaranteed pickup copy.
-            </InfoHint>
-          </span>
-          <PullsField row={row} showCost />
+        <div className="grid gap-3 text-xs text-muted-foreground">
+          <div className="grid gap-1">
+            <span className="inline-flex items-center gap-1">
+              Pulls
+              <InfoHint label="Pulls and sparks help" title="Pulls and sparks">
+                One pull costs 150 carats. One spark is 200 pulls and can be exchanged for a
+                guaranteed pickup copy.
+              </InfoHint>
+            </span>
+            <PullsField row={row} showCost />
+          </div>
+          <div className="grid gap-1">
+            <span>Tickets</span>
+            <TicketsField row={row} />
+          </div>
         </div>
         <div className="grid content-start gap-2 text-right">
           <div className="text-xs text-muted-foreground">
-            Carats avail.{' '}
-            <span className="font-medium font-mono text-foreground tabular-nums">
+            <div>Carats avail.</div>
+            <div className="font-mono text-lg font-semibold text-foreground tabular-nums">
               {formatCarats(row.caratsAvailable)}
-            </span>
+            </div>
+            <div className="font-mono text-[11px] tabular-nums">
+              → {formatCarats(row.balanceAfter)} after
+            </div>
           </div>
           {showPaid && (row.paidCaratsAvailable > 0 || row.paidBalanceAfter > 0) ? (
             <div className="text-xs text-muted-foreground">

--- a/src/modules/carat/components/sortable-plan-row.tsx
+++ b/src/modules/carat/components/sortable-plan-row.tsx
@@ -7,6 +7,7 @@ import { CopiesOddsBar } from '@/modules/carat/components/copies-odds-bar';
 import { UmaOddsBar } from '@/modules/carat/components/uma-odds-bar';
 import { PlanDragHandle } from '@/modules/carat/components/plan-drag-handle';
 import { PullsField } from '@/modules/carat/components/pulls-field';
+import { TicketsField } from '@/modules/carat/components/tickets-field';
 import { RemovePlannedBannerButton } from '@/modules/carat/components/remove-planned-banner-button';
 import {
   characterPickupCount,
@@ -43,10 +44,14 @@ export function SortablePlanRow(props: SortablePlanRowProps) {
         <BannerIdentity row={row} showWindow />
       </td>
       <td className="px-2 py-3 text-right font-mono tabular-nums">
-        {formatCarats(row.caratsAvailable)}
+        <div className="text-base font-semibold text-foreground">{formatCarats(row.caratsAvailable)}</div>
+        <div className="text-[11px] text-muted-foreground">→ {formatCarats(row.balanceAfter)} after</div>
       </td>
       <td className="w-44 min-w-44 px-2 py-3">
         <PullsField row={row} showCost density="table" />
+      </td>
+      <td className="w-44 min-w-44 px-2 py-3">
+        <TicketsField row={row} density="table" />
       </td>
       {showPaid ? (
         <td className="px-2 py-3 text-right font-mono tabular-nums">

--- a/src/modules/carat/components/summary-stats.tsx
+++ b/src/modules/carat/components/summary-stats.tsx
@@ -95,11 +95,16 @@ export function SummaryStats() {
       </div>
 
       {/* Supporting context — grouped, visually subordinate to the verdict. */}
-      <div className="grid grid-cols-1 divide-y rounded-xl border bg-card shadow-sm sm:grid-cols-3 sm:divide-x sm:divide-y-0">
+      <div className="grid grid-cols-1 divide-y rounded-xl border bg-card shadow-sm sm:grid-cols-4 sm:divide-x sm:divide-y-0">
         <SecondaryMetric
           label="Current Carats"
           value={settings.startingFreeCarats.toLocaleString()}
-          sub={`${settings.trackPaidCarats ? '+ paid pool tracked' : '+ paid not tracked'} · ${(settings.umaTickets + settings.supportTickets).toLocaleString()} tickets`}
+          sub={settings.trackPaidCarats ? '+ paid pool tracked' : '+ paid not tracked'}
+        />
+        <SecondaryMetric
+          label="Starting Tickets"
+          value={`${settings.umaTickets.toLocaleString()} / ${settings.supportTickets.toLocaleString()}`}
+          sub="Uma / Support · typed pools"
         />
         <SecondaryMetric
           label="Monthly Income"

--- a/src/modules/carat/components/tickets-field.tsx
+++ b/src/modules/carat/components/tickets-field.tsx
@@ -1,0 +1,58 @@
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { formatCarats } from '@/modules/carat/components/banner-plan-format';
+import { resolveBannerLabel } from '@/modules/carat/data/card-names';
+import type { BannerPlanRow } from '@/modules/carat/model/plan';
+import { setPlannedTicketsUsed } from '@/store/carat.store';
+import { cn } from '@/lib/utils';
+
+type TicketsFieldProps = {
+  row: BannerPlanRow;
+  density?: 'table' | 'card';
+};
+
+function ticketLabel(row: BannerPlanRow) {
+  return row.ticketType === 'uma' ? 'Uma' : 'Support';
+}
+
+function maxTicketsForRow(row: BannerPlanRow) {
+  return Math.min(row.ticketsAvailable, Math.max(0, Math.floor(row.plannedBanner.plannedPulls || 0)));
+}
+
+export function TicketsField(props: TicketsFieldProps) {
+  const { row, density = 'card' } = props;
+  const isAuto = row.plannedBanner.ticketsUsed === undefined;
+  const maxTickets = maxTicketsForRow(row);
+  const label = ticketLabel(row);
+  const updateTickets = (value: number) => setPlannedTicketsUsed(row.event.id, value);
+  const resetToAuto = () => setPlannedTicketsUsed(row.event.id, undefined);
+
+  return (
+    <div className={cn('grid', density === 'table' ? 'gap-1.5' : 'gap-1')}>
+      <div className="flex items-center gap-2">
+        <Input
+          type="number"
+          min={0}
+          max={maxTickets}
+          value={row.ticketsUsed}
+          onChange={(event) => updateTickets(Number(event.target.value))}
+          className="font-mono text-right tabular-nums"
+          aria-label={`${label} tickets to use on ${resolveBannerLabel(row.event)}`}
+        />
+        <span className="min-w-fit text-xs text-muted-foreground">/ {maxTickets}</span>
+      </div>
+      <div className="font-mono text-[11px] text-muted-foreground tabular-nums">
+        {row.ticketsSaved > 0 ? `Saves ${formatCarats(row.ticketsSaved)} · ` : ''}
+        {row.ticketsRemaining.toLocaleString()} {label.toLowerCase()} left
+      </div>
+      <div className="flex items-center gap-2 text-[11px] text-muted-foreground">
+        <span>{isAuto ? 'Auto-filling earliest banner' : 'Manual ticket allocation'}</span>
+        {!isAuto ? (
+          <Button type="button" size="xs" variant="link" className="h-auto px-0" onClick={resetToAuto}>
+            reset auto
+          </Button>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/src/modules/carat/components/tickets-field.tsx
+++ b/src/modules/carat/components/tickets-field.tsx
@@ -24,7 +24,8 @@ export function TicketsField(props: TicketsFieldProps) {
   const isAuto = row.plannedBanner.ticketsUsed === undefined;
   const maxTickets = maxTicketsForRow(row);
   const label = ticketLabel(row);
-  const updateTickets = (value: number) => setPlannedTicketsUsed(row.event.id, value);
+  const updateTickets = (value: number) =>
+    setPlannedTicketsUsed(row.event.id, Math.min(maxTickets, Math.max(0, value || 0)));
   const resetToAuto = () => setPlannedTicketsUsed(row.event.id, undefined);
 
   return (

--- a/src/modules/carat/model/plan.test.ts
+++ b/src/modules/carat/model/plan.test.ts
@@ -200,4 +200,84 @@ describe('computePlan', () => {
     expect(rows[0].cost).toBe(0);
     expect(rows[0].ticketsRemaining).toBe(10);
   });
+
+  it('treats negative starting ticket settings as zero', () => {
+    const rows = computePlan(
+      { ...settings, umaTickets: -5, supportTickets: -3 },
+      timeline([banner('uma', 1)]),
+      [{ id: 'uma', plannedPulls: 10, startingDupes: 0, copyGoals: {}, ownedCopies: {}, order: 0 }]
+    );
+
+    expect(rows[0].ticketsAvailable).toBe(0);
+    expect(rows[0].ticketsUsed).toBe(0);
+    expect(rows[0].cost).toBe(10 * CARAT_PER_PULL);
+  });
+
+  it('does not let one ticket type pay for the other banner type', () => {
+    // Only uma tickets, but the planned banner is a support banner.
+    const rows = computePlan(
+      { ...settings, umaTickets: 20, supportTickets: 0 },
+      timeline([banner('support', 1, 'support')]),
+      [
+        {
+          id: 'support',
+          plannedPulls: 8,
+          startingDupes: 0,
+          copyGoals: {},
+          ownedCopies: {},
+          order: 0
+        }
+      ]
+    );
+
+    expect(rows[0].ticketType).toBe('support');
+    expect(rows[0].ticketsAvailable).toBe(0);
+    expect(rows[0].ticketsUsed).toBe(0);
+    expect(rows[0].cost).toBe(8 * CARAT_PER_PULL);
+  });
+
+  it('lets an explicit 0 save tickets for a later banner of the same type', () => {
+    const rows = computePlan(
+      { ...settings, umaTickets: 4 },
+      timeline([banner('first', 1), banner('second', 2)]),
+      [
+        {
+          id: 'first',
+          plannedPulls: 10,
+          startingDupes: 0,
+          copyGoals: {},
+          ownedCopies: {},
+          ticketsUsed: 0,
+          order: 0
+        },
+        { id: 'second', plannedPulls: 10, startingDupes: 0, copyGoals: {}, ownedCopies: {}, order: 1 }
+      ]
+    );
+
+    expect(rows[0].ticketsUsed).toBe(0);
+    expect(rows[0].ticketsRemaining).toBe(4);
+    expect(rows[1].ticketsAvailable).toBe(4);
+    expect(rows[1].ticketsUsed).toBe(4);
+  });
+
+  it('floors fractional planned pulls consistently for cost and allocation', () => {
+    const rows = computePlan(
+      { ...settings, umaTickets: 2 },
+      timeline([banner('uma', 1)]),
+      [
+        {
+          id: 'uma',
+          plannedPulls: 10.9,
+          startingDupes: 0,
+          copyGoals: {},
+          ownedCopies: {},
+          order: 0
+        }
+      ]
+    );
+
+    // 10 pulls after flooring, 2 covered by tickets -> 8 carat-pulls.
+    expect(rows[0].ticketsUsed).toBe(2);
+    expect(rows[0].cost).toBe(8 * CARAT_PER_PULL);
+  });
 });

--- a/src/modules/carat/model/plan.test.ts
+++ b/src/modules/carat/model/plan.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { TimelineEvent, TimelinePayload } from '@/modules/carat/data/timeline-types';
+import { CARAT_PER_PULL } from '@/modules/carat/model/income-tables';
 import { computePlan } from '@/modules/carat/model/plan';
 import type { CaratSettings, PlannedBanner } from '@/store/carat.store';
 
@@ -10,11 +11,15 @@ function daysFromNow(days: number) {
   return date.toISOString();
 }
 
-function banner(id: string, days: number): TimelineEvent {
+function banner(
+  id: string,
+  days: number,
+  cardType: 'character' | 'support' | null = 'character'
+): TimelineEvent {
   return {
     id,
     type: 'banner',
-    card_type: 'character',
+    card_type: cardType,
     global_release_date: daysFromNow(days),
     estimated_end_date: daysFromNow(days + 10),
     prediction: { kind: 'confirmed' }
@@ -88,5 +93,111 @@ describe('computePlan', () => {
     expect(rows[0].paidBalanceAfter).toBe(0);
     expect(rows[0].freeBalanceAfter).toBeGreaterThanOrEqual(0);
     expect(rows[0].affordable).toBe(true);
+  });
+
+  it('auto-fills uma tickets for the earliest character banner and reduces cost', () => {
+    const rows = computePlan(
+      { ...settings, umaTickets: 3 },
+      timeline([banner('uma', 1)]),
+      [{ id: 'uma', plannedPulls: 10, startingDupes: 0, copyGoals: {}, ownedCopies: {}, order: 0 }]
+    );
+
+    expect(rows[0].ticketType).toBe('uma');
+    expect(rows[0].ticketsAvailable).toBe(3);
+    expect(rows[0].ticketsUsed).toBe(3);
+    expect(rows[0].ticketsSaved).toBe(3 * CARAT_PER_PULL);
+    expect(rows[0].ticketsRemaining).toBe(0);
+    expect(rows[0].cost).toBe(7 * CARAT_PER_PULL);
+  });
+
+  it('routes support banners to support tickets without consuming uma tickets', () => {
+    const rows = computePlan(
+      { ...settings, umaTickets: 10, supportTickets: 2 },
+      timeline([banner('support', 1, 'support')]),
+      [
+        {
+          id: 'support',
+          plannedPulls: 5,
+          startingDupes: 0,
+          copyGoals: {},
+          ownedCopies: {},
+          order: 0
+        }
+      ]
+    );
+
+    expect(rows[0].ticketType).toBe('support');
+    expect(rows[0].ticketsAvailable).toBe(2);
+    expect(rows[0].ticketsUsed).toBe(2);
+    expect(rows[0].cost).toBe(3 * CARAT_PER_PULL);
+  });
+
+  it('depletes typed ticket pools across matching banners by date', () => {
+    const first = banner('first', 1);
+    const second = banner('second', 2);
+    const rows = computePlan(
+      { ...settings, umaTickets: 5 },
+      timeline([second, first]),
+      [
+        { id: 'second', plannedPulls: 3, startingDupes: 0, copyGoals: {}, ownedCopies: {}, order: 0 },
+        { id: 'first', plannedPulls: 3, startingDupes: 0, copyGoals: {}, ownedCopies: {}, order: 1 }
+      ]
+    );
+
+    expect(rows.map((row) => row.event.id)).toEqual(['first', 'second']);
+    expect(rows[0].ticketsAvailable).toBe(5);
+    expect(rows[0].ticketsUsed).toBe(3);
+    expect(rows[0].ticketsRemaining).toBe(2);
+    expect(rows[1].ticketsAvailable).toBe(2);
+    expect(rows[1].ticketsUsed).toBe(2);
+    expect(rows[1].ticketsRemaining).toBe(0);
+  });
+
+  it('honors explicit ticket allocation and leaves unused tickets for later banners', () => {
+    const rows = computePlan(
+      { ...settings, umaTickets: 5 },
+      timeline([banner('manual', 1), banner('auto', 2)]),
+      [
+        {
+          id: 'manual',
+          plannedPulls: 3,
+          startingDupes: 0,
+          copyGoals: {},
+          ownedCopies: {},
+          ticketsUsed: 1,
+          order: 0
+        },
+        { id: 'auto', plannedPulls: 10, startingDupes: 0, copyGoals: {}, ownedCopies: {}, order: 1 }
+      ]
+    );
+
+    expect(rows[0].ticketsUsed).toBe(1);
+    expect(rows[0].ticketsRemaining).toBe(4);
+    expect(rows[1].ticketsAvailable).toBe(4);
+    expect(rows[1].ticketsUsed).toBe(4);
+    expect(rows[1].cost).toBe(6 * CARAT_PER_PULL);
+  });
+
+  it('clamps explicit ticket allocation to planned pulls and available pool', () => {
+    const rows = computePlan(
+      { ...settings, supportTickets: 20 },
+      timeline([banner('support', 1, 'support')]),
+      [
+        {
+          id: 'support',
+          plannedPulls: 10,
+          startingDupes: 0,
+          copyGoals: {},
+          ownedCopies: {},
+          ticketsUsed: 99,
+          order: 0
+        }
+      ]
+    );
+
+    expect(rows[0].ticketsUsed).toBe(10);
+    expect(rows[0].ticketsSaved).toBe(10 * CARAT_PER_PULL);
+    expect(rows[0].cost).toBe(0);
+    expect(rows[0].ticketsRemaining).toBe(10);
   });
 });

--- a/src/modules/carat/model/plan.ts
+++ b/src/modules/carat/model/plan.ts
@@ -4,12 +4,19 @@ import { CARAT_PER_PULL } from '@/modules/carat/model/income-tables';
 import { totalPaidCaratsFromPurchases, type PaidPackPurchases } from '@/modules/carat/model/paid';
 import type { CaratSettings, PlannedBanner } from '@/store/carat.store';
 
+export type TicketType = 'uma' | 'support';
+
 export type BannerPlanRow = {
   event: TimelineEvent;
   plannedBanner: PlannedBanner;
   caratsAvailable: number;
   paidCaratsAvailable: number;
   freeCaratsAvailable: number;
+  ticketType: TicketType;
+  ticketsAvailable: number;
+  ticketsUsed: number;
+  ticketsSaved: number;
+  ticketsRemaining: number;
   cost: number;
   paidCost: number;
   freeCost: number;
@@ -26,6 +33,21 @@ function eventStartDate(event: TimelineEvent) {
 function eventStartTime(event: TimelineEvent) {
   const time = eventStartDate(event).getTime();
   return Number.isFinite(time) ? time : Number.POSITIVE_INFINITY;
+}
+
+function ticketTypeForEvent(event: TimelineEvent): TicketType {
+  return event.card_type === 'character' ? 'uma' : 'support';
+}
+
+function ticketAllocation(plannedBanner: PlannedBanner, ticketsAvailable: number) {
+  const plannedPulls = Math.max(0, Math.floor(plannedBanner.plannedPulls || 0));
+  const maxTicketsUsed = Math.min(ticketsAvailable, plannedPulls);
+
+  if (plannedBanner.ticketsUsed === undefined) {
+    return maxTicketsUsed;
+  }
+
+  return Math.min(maxTicketsUsed, Math.max(0, Math.floor(plannedBanner.ticketsUsed || 0)));
 }
 
 export function computePlan(
@@ -49,13 +71,27 @@ export function computePlan(
     ? settings.startingPaidCarats +
       totalPaidCaratsFromPurchases(paidPurchases, settings.server).paidCarats
     : 0;
+  let runningUmaTickets = Math.max(0, Math.floor(settings.umaTickets || 0));
+  let runningSupportTickets = Math.max(0, Math.floor(settings.supportTickets || 0));
 
   return rows.map(({ event, plannedBanner }) => {
     const startDate = eventStartDate(event);
     const income = projectIncome(settings, timeline, previousDate, startDate);
     runningFreeBalance += income.carats + income.tickets * CARAT_PER_PULL;
 
-    const cost = plannedBanner.plannedPulls * CARAT_PER_PULL;
+    const ticketType = ticketTypeForEvent(event);
+    const ticketsAvailable = ticketType === 'uma' ? runningUmaTickets : runningSupportTickets;
+    const ticketsUsed = ticketAllocation(plannedBanner, ticketsAvailable);
+    const ticketsSaved = ticketsUsed * CARAT_PER_PULL;
+
+    if (ticketType === 'uma') {
+      runningUmaTickets -= ticketsUsed;
+    } else {
+      runningSupportTickets -= ticketsUsed;
+    }
+
+    const ticketedPulls = Math.max(0, plannedBanner.plannedPulls - ticketsUsed);
+    const cost = ticketedPulls * CARAT_PER_PULL;
     const paidCost = settings.trackPaidCarats ? Math.min(runningPaidBalance, cost) : 0;
     const freeCost = cost - paidCost;
     runningPaidBalance -= paidCost;
@@ -71,6 +107,11 @@ export function computePlan(
       caratsAvailable: freeCaratsAvailable + runningPaidBalance,
       paidCaratsAvailable: runningPaidBalance + paidCost,
       freeCaratsAvailable,
+      ticketType,
+      ticketsAvailable,
+      ticketsUsed,
+      ticketsSaved,
+      ticketsRemaining: ticketType === 'uma' ? runningUmaTickets : runningSupportTickets,
       cost,
       paidCost,
       freeCost,

--- a/src/modules/carat/model/plan.ts
+++ b/src/modules/carat/model/plan.ts
@@ -39,9 +39,17 @@ function ticketTypeForEvent(event: TimelineEvent): TicketType {
   return event.card_type === 'character' ? 'uma' : 'support';
 }
 
-function ticketAllocation(plannedBanner: PlannedBanner, ticketsAvailable: number) {
-  const plannedPulls = Math.max(0, Math.floor(plannedBanner.plannedPulls || 0));
-  const maxTicketsUsed = Math.min(ticketsAvailable, plannedPulls);
+function plannedPullsOf(plannedBanner: PlannedBanner) {
+  return Math.max(0, Math.floor(plannedBanner.plannedPulls || 0));
+}
+
+function ticketAllocation(
+  plannedBanner: PlannedBanner,
+  ticketsAvailable: number,
+  plannedPulls: number
+) {
+  // ticketsAvailable is clamped defensively; the running pools are already >= 0.
+  const maxTicketsUsed = Math.min(Math.max(0, ticketsAvailable), plannedPulls);
 
   if (plannedBanner.ticketsUsed === undefined) {
     return maxTicketsUsed;
@@ -81,7 +89,8 @@ export function computePlan(
 
     const ticketType = ticketTypeForEvent(event);
     const ticketsAvailable = ticketType === 'uma' ? runningUmaTickets : runningSupportTickets;
-    const ticketsUsed = ticketAllocation(plannedBanner, ticketsAvailable);
+    const plannedPulls = plannedPullsOf(plannedBanner);
+    const ticketsUsed = ticketAllocation(plannedBanner, ticketsAvailable, plannedPulls);
     const ticketsSaved = ticketsUsed * CARAT_PER_PULL;
 
     if (ticketType === 'uma') {
@@ -90,7 +99,7 @@ export function computePlan(
       runningSupportTickets -= ticketsUsed;
     }
 
-    const ticketedPulls = Math.max(0, plannedBanner.plannedPulls - ticketsUsed);
+    const ticketedPulls = Math.max(0, plannedPulls - ticketsUsed);
     const cost = ticketedPulls * CARAT_PER_PULL;
     const paidCost = settings.trackPaidCarats ? Math.min(runningPaidBalance, cost) : 0;
     const freeCost = cost - paidCost;

--- a/src/store/carat.store.ts
+++ b/src/store/carat.store.ts
@@ -34,6 +34,9 @@ export type PlannedBanner = {
   // Copies the player already owns per rate-up card (reruns), keyed by pickup
   // card id. These reduce how many copies the banner needs to supply.
   ownedCopies: Record<string, number>;
+  // Explicit per-banner ticket allocation. Undefined means auto-fill from the
+  // matching typed ticket pool in chronological order.
+  ticketsUsed?: number;
   order: number;
 };
 
@@ -100,7 +103,11 @@ export const useCaratStore = create<CaratStore>()(
         plannedBanners: (state.plannedBanners ?? defaultPlannedBanners).map((banner) => ({
           ...banner,
           copyGoals: banner.copyGoals ?? {},
-          ownedCopies: banner.ownedCopies ?? {}
+          ownedCopies: banner.ownedCopies ?? {},
+          ticketsUsed:
+            typeof banner.ticketsUsed === 'number'
+              ? Math.max(0, Math.floor(banner.ticketsUsed || 0))
+              : undefined
         })),
         paidPurchases: state.paidPurchases ?? {},
         selectorChoices: state.selectorChoices ?? {}
@@ -174,6 +181,19 @@ export function setPlannedPulls(id: string, plannedPulls: number) {
     plannedBanners: state.plannedBanners.map((banner) =>
       banner.id === id ? { ...banner, plannedPulls } : banner
     )
+  }));
+}
+
+export function setPlannedTicketsUsed(id: string, ticketsUsed: number | undefined) {
+  useCaratStore.setState((state) => ({
+    plannedBanners: state.plannedBanners.map((banner) => {
+      if (banner.id !== id) return banner;
+      if (ticketsUsed === undefined) {
+        const { ticketsUsed: _ticketsUsed, ...rest } = banner;
+        return rest;
+      }
+      return { ...banner, ticketsUsed: Math.max(0, Math.floor(ticketsUsed || 0)) };
+    })
   }));
 }
 


### PR DESCRIPTION
## What

Reworks the carat planner's ticket handling and per-banner estimate, addressing user feedback (Latias4Ever) on the crystal/ticket calculator.

1. **Fixes the "tickets aren't counted" bug** — starting Uma/Support tickets were inputs that never affected any banner. They now seed spendable, type-aware pools that reduce banner cost.
2. **Adds a per-banner ticket slot** — each banner can allocate matching tickets, deducting from the running estimate.
3. **Clearer per-banner estimate** — the "Carats avail." column is restyled (prominent value + "→ balance after").

## How tickets work now

```mermaid
flowchart LR
  U["Uma tickets (start)"] --> UP["Uma pool"]
  S["Support tickets (start)"] --> SP["Support pool"]
  UP -->|character banners only| AB["per-banner allocation<br/>(auto-fill earliest, editable)"]
  SP -->|support banners only| AB
  AB --> C["cost = (pulls − tickets) × 150"]
  C --> BAL["running balance / verdict"]
```

- Uma tickets apply only to **character** banners, Support tickets only to **support** banners (`event.card_type`).
- Each ticket = 1 free pull (saves `CARAT_PER_PULL` = 150 carats).
- Allocation **auto-fills greedily by date** (earliest matching banner first) and is **editable** per banner; a reset link returns a banner to auto.
- Tickets reduce **carat cost only**, never pull count — so the Odds bars and copy goals are unchanged.

## Model

`PlannedBanner` gains an optional `ticketsUsed?` (`undefined` = auto, number = explicit, clamped). `BannerPlanRow` exposes `ticketType`, `ticketsAvailable`, `ticketsUsed`, `ticketsSaved`, `ticketsRemaining`. `computePlan` seeds the two typed pools from settings and depletes them in chronological order (consistent with carat accrual). Persisted banners without `ticketsUsed` migrate to auto.

## Edge cases hardened

- Negative starting ticket/carat settings → treated as 0 (input clamp + compute seed clamp).
- Fractional/NaN planned pulls floored consistently for both allocation and cost.
- Manual allocation clamped to the allocatable max (stored value never diverges from what's shown).
- One ticket type never pays for the other banner type.
- Explicit `0` saves tickets for a later same-type banner.

## UI

New **Tickets** column (wide table) / field (mobile cards) showing `[input] / max {type}` + "saves X · Y left" + auto/reset. Cost line appends `(−N tix)` in green when tickets apply. Summary surfaces the two starting ticket pools.

## Tests

`plan.test.ts` covers auto-fill, type routing, depletion, explicit clamp/zero, negative settings, cross-type isolation, and fractional flooring. Full suite: **323 passed**, typecheck + lint clean.
