### PR TITLE
feat(skill-planner): inline hint level steppers

### DIFF
--- a/src/modules/runners/components/runner-card/skill-row.tsx
+++ b/src/modules/runners/components/runner-card/skill-row.tsx
@@ -23,26 +23,25 @@ type RunnerCardSkillRowProps = {
 export function RunnerCardSkillRow(props: Readonly<RunnerCardSkillRowProps>) {
   const { dismissable } = props;
 
+  // Mirrors the planner candidate card composition: identity + detail actions
+  // on the top row, hint stepper + cost sharing the bottom row on one axis.
+  // `empty:hidden` collapses the bottom row when both render null (unique
+  // skills, or SP cost editing disabled), leaving a compact single-row card.
   return (
     <SkillItemRoot>
       <SkillItemRail />
       <SkillItemBody className="flex-col">
         <SkillItemMain className="p-1 px-1">
           <SkillItemIdentity labelProps={{ className: 'text-xs' }} />
+          <SkillItemActions>
+            <SkillItemDetailsActions dismissable={dismissable} />
+          </SkillItemActions>
         </SkillItemMain>
 
-        {/* Own row so the stepper never competes for width with the cost +
-            actions in the dense 2-column runner panel (that clipped the minus
-            button). `empty:hidden` collapses the row when the stepper renders
-            null (unique/obtained skills, or SP cost disabled). */}
-        <div className="flex px-1 pb-1 empty:hidden">
+        <div className="flex items-center gap-2 px-1 pb-1 empty:hidden">
           <SkillItemHintStepper />
+          <SkillItemCostAction layout="inline" className="ml-auto" />
         </div>
-
-        <SkillItemActions className="justify-end bg-card">
-          <SkillItemCostAction layout="inline" />
-          <SkillItemDetailsActions dismissable={dismissable} />
-        </SkillItemActions>
       </SkillItemBody>
     </SkillItemRoot>
   );

--- a/src/modules/runners/components/runner-card/skill-row.tsx
+++ b/src/modules/runners/components/runner-card/skill-row.tsx
@@ -31,10 +31,15 @@ export function RunnerCardSkillRow(props: Readonly<RunnerCardSkillRowProps>) {
           <SkillItemIdentity labelProps={{ className: 'text-xs' }} />
         </SkillItemMain>
 
-        <SkillItemActions className="justify-end gap-2 bg-card">
-          {/* mr-auto pushes the stepper to the left; when it renders null
-              (obtained / SP cost disabled) the cost + actions stay right-aligned. */}
-          <SkillItemHintStepper className="mr-auto" />
+        {/* Own row so the stepper never competes for width with the cost +
+            actions in the dense 2-column runner panel (that clipped the minus
+            button). `empty:hidden` collapses the row when the stepper renders
+            null (unique/obtained skills, or SP cost disabled). */}
+        <div className="flex px-1 pb-1 empty:hidden">
+          <SkillItemHintStepper />
+        </div>
+
+        <SkillItemActions className="justify-end bg-card">
           <SkillItemCostAction layout="inline" />
           <SkillItemDetailsActions dismissable={dismissable} />
         </SkillItemActions>

--- a/src/modules/runners/components/runner-card/skill-row.tsx
+++ b/src/modules/runners/components/runner-card/skill-row.tsx
@@ -10,6 +10,7 @@ import {
   SkillItemCostAction,
   SkillItemDetailsActions
 } from '@/modules/skills/components/skill-list/skill-item/actions';
+import { SkillItemHintStepper } from '@/modules/skills/components/skill-list/skill-item/hint-stepper';
 
 type RunnerCardSkillRowProps = {
   dismissable: boolean;
@@ -30,7 +31,10 @@ export function RunnerCardSkillRow(props: Readonly<RunnerCardSkillRowProps>) {
           <SkillItemIdentity labelProps={{ className: 'text-xs' }} />
         </SkillItemMain>
 
-        <SkillItemActions className="justify-end bg-card">
+        <SkillItemActions className="justify-end gap-2 bg-card">
+          {/* mr-auto pushes the stepper to the left; when it renders null
+              (obtained / SP cost disabled) the cost + actions stay right-aligned. */}
+          <SkillItemHintStepper className="mr-auto" />
           <SkillItemCostAction layout="inline" />
           <SkillItemDetailsActions dismissable={dismissable} />
         </SkillItemActions>

--- a/src/modules/skill-planner/components/CandidateSkillList.tsx
+++ b/src/modules/skill-planner/components/CandidateSkillList.tsx
@@ -21,6 +21,7 @@ import {
   SkillItemDetailsActions
 } from '@/modules/skills/components/skill-list/skill-item/actions';
 import { SkillItem } from '@/modules/skills/components/skill-list/skill-item/item';
+import { SkillItemHintStepper } from '@/modules/skills/components/skill-list/skill-item/hint-stepper';
 import type { SkillMeta } from '@/modules/skills/components/skill-list/skill-item/context';
 import {
   buildDedupedSkillListNetTotal,
@@ -161,7 +162,10 @@ function CandidateSkillRow() {
           <SkillItemDetailsActions dismissable className="shrink-0" />
         </SkillItemMain>
 
-        <SkillItemCostAction layout="summary" />
+        <div className="flex items-center gap-2 px-2 pb-1">
+          <SkillItemHintStepper />
+          <SkillItemCostAction layout="summary" className="flex-1" />
+        </div>
       </SkillItemBody>
     </SkillItemRoot>
   );

--- a/src/modules/skill-planner/components/HelpDialog.tsx
+++ b/src/modules/skill-planner/components/HelpDialog.tsx
@@ -1,5 +1,12 @@
 import { HelpCircleIcon } from 'lucide-react';
 import { useState } from 'react';
+import { cn } from '@/lib/utils';
+import {
+  getHintDiscountPercent,
+  HINT_LEVELS,
+  MAX_HINT_LEVEL,
+  MIN_HINT_LEVEL
+} from '@/modules/skill-planner/hint-levels';
 import { Button } from '@/components/ui/button';
 import {
   Dialog,
@@ -102,30 +109,28 @@ export function HelpDialog({ open, onOpenChange }: HelpDialogProps) {
           <div>
             <h3 className="font-semibold mb-2">Understanding Hint Levels</h3>
             <div className="bg-muted/50 rounded-lg p-3 space-y-1 text-xs">
-              <div className="flex justify-between">
-                <span>Hint Lvl 0 (No hint)</span>
-                <span className="font-medium">0% off</span>
-              </div>
-              <div className="flex justify-between">
-                <span>Hint Lvl 1</span>
-                <span className="font-medium text-blue-600">10% off</span>
-              </div>
-              <div className="flex justify-between">
-                <span>Hint Lvl 2</span>
-                <span className="font-medium text-blue-600">20% off</span>
-              </div>
-              <div className="flex justify-between">
-                <span>Hint Lvl 3</span>
-                <span className="font-medium text-green-600">30% off</span>
-              </div>
-              <div className="flex justify-between">
-                <span>Hint Lvl 4</span>
-                <span className="font-medium text-green-600">35% off</span>
-              </div>
-              <div className="flex justify-between">
-                <span>Hint Lvl 5 (Max)</span>
-                <span className="font-medium text-green-600">40% off</span>
-              </div>
+              {HINT_LEVELS.map((level) => {
+                const percent = getHintDiscountPercent(level);
+                const suffix =
+                  level === MIN_HINT_LEVEL ? ' (No hint)' : level === MAX_HINT_LEVEL ? ' (Max)' : '';
+
+                return (
+                  <div key={level} className="flex justify-between">
+                    <span>
+                      Hint Lvl {level}
+                      {suffix}
+                    </span>
+                    <span
+                      className={cn('font-medium', {
+                        'text-blue-600': percent > 0 && percent < 30,
+                        'text-green-600': percent >= 30
+                      })}
+                    >
+                      {percent}% off
+                    </span>
+                  </div>
+                );
+              })}
             </div>
           </div>
         </div>

--- a/src/modules/skill-planner/cost-calculator.ts
+++ b/src/modules/skill-planner/cost-calculator.ts
@@ -2,16 +2,7 @@ import type { CandidateSkill, CostBreakdown, HintLevel } from './types';
 import { skillsService } from '@/modules/data/services/SkillService';
 import { getBaseTier, getUpgradeTier } from '@/modules/skills/skill-relationships';
 import { isSkillCoveredByOwnedFamily } from './skill-family';
-
-// Hint level discount mapping (as shown in game screenshots)
-const HINT_DISCOUNTS: Readonly<Record<HintLevel, number>> = {
-  0: 0, // No discount
-  1: 0.1, // 10% off (Hint Lvl 1)
-  2: 0.2, // 20% off (Hint Lvl 2)
-  3: 0.3, // 30% off (Hint Lvl 3)
-  4: 0.35, // 35% off (Hint Lvl 4)
-  5: 0.4 // 40% off (Hint Lvl 5 - max)
-} as const;
+import { HINT_DISCOUNTS } from './hint-levels';
 
 /**
  * Calculate the raw discounted cost of a skill before integer rounding.

--- a/src/modules/skill-planner/hint-levels.ts
+++ b/src/modules/skill-planner/hint-levels.ts
@@ -1,0 +1,25 @@
+import type { HintLevel } from './types';
+
+/**
+ * Single source of truth for the hint-level → SP discount mapping
+ * (as shown in game). Data-free on purpose: UI components and worker-side
+ * code can import this without dragging in the skill dataset.
+ */
+export const HINT_DISCOUNTS: Readonly<Record<HintLevel, number>> = {
+  0: 0, // No hint
+  1: 0.1, // 10% off (Hint Lvl 1)
+  2: 0.2, // 20% off (Hint Lvl 2)
+  3: 0.3, // 30% off (Hint Lvl 3)
+  4: 0.35, // 35% off (Hint Lvl 4)
+  5: 0.4 // 40% off (Hint Lvl 5 - max)
+};
+
+export const HINT_LEVELS: ReadonlyArray<HintLevel> = [0, 1, 2, 3, 4, 5];
+
+export const MIN_HINT_LEVEL: HintLevel = 0;
+export const MAX_HINT_LEVEL: HintLevel = 5;
+
+/** Discount as a whole percentage (0, 10, 20, 30, 35, 40). */
+export function getHintDiscountPercent(level: HintLevel): number {
+  return Math.round((HINT_DISCOUNTS[level] ?? 0) * 100);
+}

--- a/src/modules/skills/components/cost-details.tsx
+++ b/src/modules/skills/components/cost-details.tsx
@@ -14,6 +14,12 @@ import {
   SelectValue
 } from '@/components/ui/select';
 import type { HintLevel } from '@/modules/skill-planner/types';
+import {
+  getHintDiscountPercent,
+  HINT_LEVELS,
+  MAX_HINT_LEVEL,
+  MIN_HINT_LEVEL
+} from '@/modules/skill-planner/hint-levels';
 import { calculateSkillCost } from '@/modules/skill-planner/cost-calculator';
 import {
   getRelatedSkillIds,
@@ -23,14 +29,15 @@ import {
 import { skillsService } from '@/modules/data/services/SkillService';
 import { buildSkillCostSummary } from '@/modules/skills/skill-cost-summary';
 
-const HINT_LEVEL_OPTIONS: Array<{ value: HintLevel; label: string }> = [
-  { value: 0, label: 'No hint' },
-  { value: 1, label: 'Lvl 1 (10%)' },
-  { value: 2, label: 'Lvl 2 (20%)' },
-  { value: 3, label: 'Lvl 3 (30%)' },
-  { value: 4, label: 'Lvl 4 (35%)' },
-  { value: 5, label: 'Lvl Max (40%)' }
-];
+const getHintOptionLabel = (level: HintLevel): string => {
+  if (level === MIN_HINT_LEVEL) return 'No hint';
+  const name = level === MAX_HINT_LEVEL ? 'Lvl Max' : `Lvl ${level}`;
+  return `${name} (${getHintDiscountPercent(level)}%)`;
+};
+
+const HINT_LEVEL_OPTIONS: Array<{ value: HintLevel; label: string }> = HINT_LEVELS.map(
+  (level) => ({ value: level, label: getHintOptionLabel(level) })
+);
 
 const getHintLevelLabel = (hintLevel: HintLevel) => {
   return HINT_LEVEL_OPTIONS.find((option) => option.value === hintLevel)?.label ?? 'None (0%)';

--- a/src/modules/skills/components/cost-details.tsx
+++ b/src/modules/skills/components/cost-details.tsx
@@ -6,20 +6,8 @@ import i18n from '@/i18n';
 import { memo, useMemo } from 'react';
 import { Label } from '@/components/ui/label';
 import { Checkbox } from '@/components/ui/checkbox';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue
-} from '@/components/ui/select';
+import { HintLevelStepper } from './skill-list/skill-item/hint-stepper';
 import type { HintLevel } from '@/modules/skill-planner/types';
-import {
-  getHintDiscountPercent,
-  HINT_LEVELS,
-  MAX_HINT_LEVEL,
-  MIN_HINT_LEVEL
-} from '@/modules/skill-planner/hint-levels';
 import { calculateSkillCost } from '@/modules/skill-planner/cost-calculator';
 import {
   getRelatedSkillIds,
@@ -28,20 +16,6 @@ import {
 } from '@/modules/skill-planner/skill-family';
 import { skillsService } from '@/modules/data/services/SkillService';
 import { buildSkillCostSummary } from '@/modules/skills/skill-cost-summary';
-
-const getHintOptionLabel = (level: HintLevel): string => {
-  if (level === MIN_HINT_LEVEL) return 'No hint';
-  const name = level === MAX_HINT_LEVEL ? 'Lvl Max' : `Lvl ${level}`;
-  return `${name} (${getHintDiscountPercent(level)}%)`;
-};
-
-const HINT_LEVEL_OPTIONS: Array<{ value: HintLevel; label: string }> = HINT_LEVELS.map(
-  (level) => ({ value: level, label: getHintOptionLabel(level) })
-);
-
-const getHintLevelLabel = (hintLevel: HintLevel) => {
-  return HINT_LEVEL_OPTIONS.find((option) => option.value === hintLevel)?.label ?? 'None (0%)';
-};
 
 type PrereqItemProps = {
   prereqId: string;
@@ -101,22 +75,11 @@ const PrereqItem = memo((props: PrereqItemProps) => {
           <span className="font-medium">{prereqSkill.baseCost} SP</span>
 
           <span className="text-muted-foreground">Hint Lvl</span>
-          <Select
-            value={hintLevel}
-            onValueChange={(value) => onHintLevelChange?.(prereqId, value ?? 0)}
+          <HintLevelStepper
+            level={hintLevel}
+            onChange={(level) => onHintLevelChange?.(prereqId, level)}
             disabled={!onHintLevelChange}
-          >
-            <SelectTrigger className="h-7 w-[148px] text-xs">
-              <SelectValue>{getHintLevelLabel(hintLevel)}</SelectValue>
-            </SelectTrigger>
-            <SelectContent align="end">
-              {HINT_LEVEL_OPTIONS.map((option) => (
-                <SelectItem key={option.value} value={option.value}>
-                  {option.label}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
+          />
 
           <span className="text-muted-foreground">Net Cost</span>
           <span className="font-semibold">{prereqNetCost} SP</span>
@@ -223,22 +186,11 @@ export const SkillCostDetails = () => {
 
             <div className="flex items-center justify-between gap-2">
               <span className="text-muted-foreground">Hint Lvl</span>
-              <Select
-                value={hintLevel}
-                onValueChange={(value) => onHintLevelChange?.(skillId, value ?? 0)}
+              <HintLevelStepper
+                level={hintLevel}
+                onChange={(level) => onHintLevelChange?.(skillId, level)}
                 disabled={!onHintLevelChange}
-              >
-                <SelectTrigger className="h-7 w-[148px] text-xs">
-                  <SelectValue>{getHintLevelLabel(hintLevel)}</SelectValue>
-                </SelectTrigger>
-                <SelectContent align="end">
-                  {HINT_LEVEL_OPTIONS.map((option) => (
-                    <SelectItem key={option.value} value={option.value}>
-                      {option.label}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+              />
             </div>
 
             <div className="grid grid-cols-[1fr_auto] gap-y-1 gap-x-3 items-center border-t pt-2">
@@ -277,22 +229,11 @@ export const SkillCostDetails = () => {
                 <span className="font-medium">{skill.baseCost} SP</span>
 
                 <span className="text-muted-foreground">Hint Lvl</span>
-                <Select
-                  value={hintLevel}
-                  onValueChange={(value) => onHintLevelChange?.(skillId, value ?? 0)}
+                <HintLevelStepper
+                  level={hintLevel}
+                  onChange={(level) => onHintLevelChange?.(skillId, level)}
                   disabled={!onHintLevelChange}
-                >
-                  <SelectTrigger className="h-7 w-[148px] text-xs">
-                    <SelectValue>{getHintLevelLabel(hintLevel)}</SelectValue>
-                  </SelectTrigger>
-                  <SelectContent align="end">
-                    {HINT_LEVEL_OPTIONS.map((option) => (
-                      <SelectItem key={option.value} value={option.value}>
-                        {option.label}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+                />
 
                 <span className="text-muted-foreground">Net Cost</span>
                 <span className="font-semibold">{netCost} SP</span>

--- a/src/modules/skills/components/skill-list/skill-item/hint-stepper.tsx
+++ b/src/modules/skills/components/skill-list/skill-item/hint-stepper.tsx
@@ -69,7 +69,10 @@ export function HintLevelStepper(props: Readonly<HintLevelStepperProps>) {
         <MinusIcon className="size-3.5" />
       </button>
 
-      <div className="flex h-full items-center justify-center gap-1.5 border-x border-border px-2">
+      {/* Fixed width sized to the widest state ("Lv Max 40%" ≈ 85px) so the
+          control keeps a constant footprint across all levels — no layout
+          shift while stepping. */}
+      <div className="flex h-full w-22 items-center justify-center gap-1.5 border-x border-border px-1">
         <span className="text-xs font-semibold leading-none">{label}</span>
         {level > 0 && (
           <span

--- a/src/modules/skills/components/skill-list/skill-item/hint-stepper.tsx
+++ b/src/modules/skills/components/skill-list/skill-item/hint-stepper.tsx
@@ -2,21 +2,18 @@ import { useMemo } from 'react';
 import { MinusIcon, PlusIcon } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import type { HintLevel } from '@/modules/skill-planner/types';
+import {
+  getHintDiscountPercent,
+  MAX_HINT_LEVEL,
+  MIN_HINT_LEVEL
+} from '@/modules/skill-planner/hint-levels';
 import { useSkillItem } from './context';
 
-// Presentation table for the stepper. Discount values mirror HINT_DISCOUNTS in
-// cost-calculator.ts (the canonical source); the short labels are stepper-only.
-const HINT_STEPS: ReadonlyArray<{ level: HintLevel; label: string; off: string }> = [
-  { level: 0, label: 'No hint', off: '0%' },
-  { level: 1, label: 'Lv 1', off: '10%' },
-  { level: 2, label: 'Lv 2', off: '20%' },
-  { level: 3, label: 'Lv 3', off: '30%' },
-  { level: 4, label: 'Lv 4', off: '35%' },
-  { level: 5, label: 'Lv Max', off: '40%' }
-];
-
-const MIN_LEVEL = 0;
-const MAX_LEVEL = 5;
+const getStepLabel = (level: HintLevel): string => {
+  if (level === MIN_HINT_LEVEL) return 'No hint';
+  if (level === MAX_HINT_LEVEL) return 'Lv Max';
+  return `Lv ${level}`;
+};
 
 type SkillItemHintStepperProps = {
   className?: string;
@@ -38,22 +35,23 @@ export function SkillItemHintStepper(props: Readonly<SkillItemHintStepperProps>)
   const meta = useMemo(() => getSkillMeta(skillId), [getSkillMeta, skillId]);
   const isObtained = costSummary?.isObtained ?? meta.bought ?? false;
 
-  const level = Math.min(MAX_LEVEL, Math.max(MIN_LEVEL, meta.hintLevel)) as HintLevel;
-  const step = HINT_STEPS[level];
+  const level = Math.min(MAX_HINT_LEVEL, Math.max(MIN_HINT_LEVEL, meta.hintLevel)) as HintLevel;
+  const label = getStepLabel(level);
+  const off = `${getHintDiscountPercent(level)}%`;
 
   if (!onHintLevelChange || !hasCost || isObtained) {
     return null;
   }
 
   const setLevel = (next: number) => {
-    const clamped = Math.min(MAX_LEVEL, Math.max(MIN_LEVEL, next));
+    const clamped = Math.min(MAX_HINT_LEVEL, Math.max(MIN_HINT_LEVEL, next));
     if (clamped !== level) {
       onHintLevelChange(skillId, clamped);
     }
   };
 
-  const atMin = level <= MIN_LEVEL;
-  const atMax = level >= MAX_LEVEL;
+  const atMin = level <= MIN_HINT_LEVEL;
+  const atMax = level >= MAX_HINT_LEVEL;
 
   return (
     <div
@@ -61,7 +59,7 @@ export function SkillItemHintStepper(props: Readonly<SkillItemHintStepperProps>)
         'inline-flex h-7 shrink-0 items-center overflow-hidden rounded-md border border-border bg-muted/30',
         className
       )}
-      title={`Hint ${step.label} · ${step.off} off`}
+      title={`Hint ${label} · ${off} off`}
     >
       <button
         type="button"
@@ -77,7 +75,7 @@ export function SkillItemHintStepper(props: Readonly<SkillItemHintStepperProps>)
       </button>
 
       <div className="flex h-full items-baseline gap-1.5 border-x border-border px-2">
-        <span className="text-xs font-semibold leading-none">{step.label}</span>
+        <span className="text-xs font-semibold leading-none">{label}</span>
         <span
           className={cn(
             'font-mono text-[11px] font-semibold leading-none',
@@ -87,7 +85,7 @@ export function SkillItemHintStepper(props: Readonly<SkillItemHintStepperProps>)
             level === 0 ? 'text-muted-foreground' : 'text-[#2f6b09] dark:text-primary'
           )}
         >
-          {step.off}
+          {off}
         </span>
       </div>
 

--- a/src/modules/skills/components/skill-list/skill-item/hint-stepper.tsx
+++ b/src/modules/skills/components/skill-list/skill-item/hint-stepper.tsx
@@ -74,19 +74,18 @@ export function SkillItemHintStepper(props: Readonly<SkillItemHintStepperProps>)
         <MinusIcon className="size-3.5" />
       </button>
 
-      <div className="flex h-full items-baseline gap-1.5 border-x border-border px-2">
+      <div className="flex h-full items-center justify-center gap-1.5 border-x border-border px-2">
         <span className="text-xs font-semibold leading-none">{label}</span>
-        <span
-          className={cn(
-            'font-mono text-[11px] font-semibold leading-none',
+        {level > 0 && (
+          <span
             // Light `--primary` (#66bf0d) only clears ~2.3:1 on the light control
             // surface — below AA for this small text. Use a deeper green in light
             // mode; dark `--primary` (#57a112) already passes on charcoal.
-            level === 0 ? 'text-muted-foreground' : 'text-[#2f6b09] dark:text-primary'
-          )}
-        >
-          {off}
-        </span>
+            className="font-mono text-[11px] font-semibold leading-none text-[#2f6b09] dark:text-primary"
+          >
+            {off}
+          </span>
+        )}
       </div>
 
       <button

--- a/src/modules/skills/components/skill-list/skill-item/hint-stepper.tsx
+++ b/src/modules/skills/components/skill-list/skill-item/hint-stepper.tsx
@@ -1,0 +1,107 @@
+import { useMemo } from 'react';
+import { MinusIcon, PlusIcon } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import type { HintLevel } from '@/modules/skill-planner/types';
+import { useSkillItem } from './context';
+
+// Presentation table for the stepper. Discount values mirror HINT_DISCOUNTS in
+// cost-calculator.ts (the canonical source); the short labels are stepper-only.
+const HINT_STEPS: ReadonlyArray<{ level: HintLevel; label: string; off: string }> = [
+  { level: 0, label: 'No hint', off: '0%' },
+  { level: 1, label: 'Lv 1', off: '10%' },
+  { level: 2, label: 'Lv 2', off: '20%' },
+  { level: 3, label: 'Lv 3', off: '30%' },
+  { level: 4, label: 'Lv 4', off: '35%' },
+  { level: 5, label: 'Lv Max', off: '40%' }
+];
+
+const MIN_LEVEL = 0;
+const MAX_LEVEL = 5;
+
+type SkillItemHintStepperProps = {
+  className?: string;
+};
+
+/**
+ * Inline − / + control for a skill's hint level. Reads the current level from
+ * the shared SkillItem context and writes through the same `onHintLevelChange`
+ * action the cost popover's Select uses, so both stay in sync.
+ *
+ * Renders nothing when hint tuning does not apply: no `onHintLevelChange`
+ * handler, or the skill is already obtained (cost 0, hint irrelevant).
+ */
+export function SkillItemHintStepper(props: Readonly<SkillItemHintStepperProps>) {
+  const { className } = props;
+  const { skillId, getSkillMeta, onHintLevelChange, costSummary } = useSkillItem();
+
+  const meta = useMemo(() => getSkillMeta(skillId), [getSkillMeta, skillId]);
+  const isObtained = costSummary?.isObtained ?? meta.bought ?? false;
+
+  const level = Math.min(MAX_LEVEL, Math.max(MIN_LEVEL, meta.hintLevel)) as HintLevel;
+  const step = HINT_STEPS[level];
+
+  if (!onHintLevelChange || isObtained) {
+    return null;
+  }
+
+  const setLevel = (next: number) => {
+    const clamped = Math.min(MAX_LEVEL, Math.max(MIN_LEVEL, next));
+    if (clamped !== level) {
+      onHintLevelChange(skillId, clamped);
+    }
+  };
+
+  const atMin = level <= MIN_LEVEL;
+  const atMax = level >= MAX_LEVEL;
+
+  return (
+    <div
+      className={cn(
+        'inline-flex h-7 shrink-0 items-center overflow-hidden rounded-md border border-border bg-muted/30',
+        className
+      )}
+      title={`Hint ${step.label} · ${step.off} off`}
+    >
+      <button
+        type="button"
+        aria-label="Lower hint level"
+        disabled={atMin}
+        onClick={(event) => {
+          event.stopPropagation();
+          setLevel(level - 1);
+        }}
+        className="grid h-full w-6 place-items-center text-foreground transition-colors hover:bg-muted disabled:cursor-not-allowed disabled:text-muted-foreground/40"
+      >
+        <MinusIcon className="size-3.5" />
+      </button>
+
+      <div className="flex h-full items-baseline gap-1.5 border-x border-border px-2">
+        <span className="text-xs font-semibold leading-none">{step.label}</span>
+        <span
+          className={cn(
+            'font-mono text-[11px] font-semibold leading-none',
+            // Light `--primary` (#66bf0d) only clears ~2.3:1 on the light control
+            // surface — below AA for this small text. Use a deeper green in light
+            // mode; dark `--primary` (#57a112) already passes on charcoal.
+            level === 0 ? 'text-muted-foreground' : 'text-[#2f6b09] dark:text-primary'
+          )}
+        >
+          {step.off}
+        </span>
+      </div>
+
+      <button
+        type="button"
+        aria-label="Raise hint level"
+        disabled={atMax}
+        onClick={(event) => {
+          event.stopPropagation();
+          setLevel(level + 1);
+        }}
+        className="grid h-full w-6 place-items-center text-foreground transition-colors hover:bg-muted disabled:cursor-not-allowed disabled:text-muted-foreground/40"
+      >
+        <PlusIcon className="size-3.5" />
+      </button>
+    </div>
+  );
+}

--- a/src/modules/skills/components/skill-list/skill-item/hint-stepper.tsx
+++ b/src/modules/skills/components/skill-list/skill-item/hint-stepper.tsx
@@ -15,43 +15,38 @@ const getStepLabel = (level: HintLevel): string => {
   return `Lv ${level}`;
 };
 
-type SkillItemHintStepperProps = {
+const clampLevel = (level: number): HintLevel => {
+  return Math.min(MAX_HINT_LEVEL, Math.max(MIN_HINT_LEVEL, level)) as HintLevel;
+};
+
+type HintLevelStepperProps = {
+  level: HintLevel;
+  onChange: (level: HintLevel) => void;
+  disabled?: boolean;
   className?: string;
 };
 
 /**
- * Inline − / + control for a skill's hint level. Reads the current level from
- * the shared SkillItem context and writes through the same `onHintLevelChange`
- * action the cost popover's Select uses, so both stay in sync.
- *
- * Renders nothing when hint tuning does not apply: no `onHintLevelChange`
- * handler, the skill has no purchasable cost (e.g. unique skills), or the
- * skill is already obtained (cost 0, hint irrelevant).
+ * Controlled − / + hint level control (0–5). Shows the level label with the
+ * discount percentage when a hint is set. Used inline on skill cards (via
+ * SkillItemHintStepper) and per-row in the cost-details popover.
  */
-export function SkillItemHintStepper(props: Readonly<SkillItemHintStepperProps>) {
-  const { className } = props;
-  const { skillId, getSkillMeta, onHintLevelChange, costSummary, hasCost } = useSkillItem();
+export function HintLevelStepper(props: Readonly<HintLevelStepperProps>) {
+  const { level: rawLevel, onChange, disabled = false, className } = props;
 
-  const meta = useMemo(() => getSkillMeta(skillId), [getSkillMeta, skillId]);
-  const isObtained = costSummary?.isObtained ?? meta.bought ?? false;
-
-  const level = Math.min(MAX_HINT_LEVEL, Math.max(MIN_HINT_LEVEL, meta.hintLevel)) as HintLevel;
+  const level = clampLevel(rawLevel);
   const label = getStepLabel(level);
   const off = `${getHintDiscountPercent(level)}%`;
 
-  if (!onHintLevelChange || !hasCost || isObtained) {
-    return null;
-  }
-
   const setLevel = (next: number) => {
-    const clamped = Math.min(MAX_HINT_LEVEL, Math.max(MIN_HINT_LEVEL, next));
+    const clamped = clampLevel(next);
     if (clamped !== level) {
-      onHintLevelChange(skillId, clamped);
+      onChange(clamped);
     }
   };
 
-  const atMin = level <= MIN_HINT_LEVEL;
-  const atMax = level >= MAX_HINT_LEVEL;
+  const atMin = disabled || level <= MIN_HINT_LEVEL;
+  const atMax = disabled || level >= MAX_HINT_LEVEL;
 
   return (
     <div
@@ -101,5 +96,38 @@ export function SkillItemHintStepper(props: Readonly<SkillItemHintStepperProps>)
         <PlusIcon className="size-3.5" />
       </button>
     </div>
+  );
+}
+
+type SkillItemHintStepperProps = {
+  className?: string;
+};
+
+/**
+ * Context-wired stepper for a skill card. Reads the current level from the
+ * shared SkillItem context and writes through the same `onHintLevelChange`
+ * action the cost popover uses, so both stay in sync.
+ *
+ * Renders nothing when hint tuning does not apply: no `onHintLevelChange`
+ * handler, the skill has no purchasable cost (e.g. unique skills), or the
+ * skill is already obtained (cost 0, hint irrelevant).
+ */
+export function SkillItemHintStepper(props: Readonly<SkillItemHintStepperProps>) {
+  const { className } = props;
+  const { skillId, getSkillMeta, onHintLevelChange, costSummary, hasCost } = useSkillItem();
+
+  const meta = useMemo(() => getSkillMeta(skillId), [getSkillMeta, skillId]);
+  const isObtained = costSummary?.isObtained ?? meta.bought ?? false;
+
+  if (!onHintLevelChange || !hasCost || isObtained) {
+    return null;
+  }
+
+  return (
+    <HintLevelStepper
+      level={clampLevel(meta.hintLevel)}
+      onChange={(level) => onHintLevelChange(skillId, level)}
+      className={className}
+    />
   );
 }

--- a/src/modules/skills/components/skill-list/skill-item/hint-stepper.tsx
+++ b/src/modules/skills/components/skill-list/skill-item/hint-stepper.tsx
@@ -28,11 +28,12 @@ type SkillItemHintStepperProps = {
  * action the cost popover's Select uses, so both stay in sync.
  *
  * Renders nothing when hint tuning does not apply: no `onHintLevelChange`
- * handler, or the skill is already obtained (cost 0, hint irrelevant).
+ * handler, the skill has no purchasable cost (e.g. unique skills), or the
+ * skill is already obtained (cost 0, hint irrelevant).
  */
 export function SkillItemHintStepper(props: Readonly<SkillItemHintStepperProps>) {
   const { className } = props;
-  const { skillId, getSkillMeta, onHintLevelChange, costSummary } = useSkillItem();
+  const { skillId, getSkillMeta, onHintLevelChange, costSummary, hasCost } = useSkillItem();
 
   const meta = useMemo(() => getSkillMeta(skillId), [getSkillMeta, skillId]);
   const isObtained = costSummary?.isObtained ?? meta.bought ?? false;
@@ -40,7 +41,7 @@ export function SkillItemHintStepper(props: Readonly<SkillItemHintStepperProps>)
   const level = Math.min(MAX_LEVEL, Math.max(MIN_LEVEL, meta.hintLevel)) as HintLevel;
   const step = HINT_STEPS[level];
 
-  if (!onHintLevelChange || isObtained) {
+  if (!onHintLevelChange || !hasCost || isObtained) {
     return null;
   }
 


### PR DESCRIPTION
Setting a skill's hint level used to take three clicks through a popover Select — per skill. Discord feedback ("I can just click arrows… it takes so long to fill the hints") asked for alphalator-style inline arrows. This adds a − / + hint stepper used consistently across every surface that edits hints, backed by a single source of truth for the discount table.

## One control, one data source

```mermaid
flowchart LR
  HL["hint-levels.ts<br/>(data-free: discounts, min/max, %)"] --> CC["cost-calculator.ts"]
  HL --> HS["HintLevelStepper<br/>(controlled primitive)"]
  HL --> HD["HelpDialog table"]
  HS --> W["SkillItemHintStepper<br/>(context-wired wrapper)"]
  W --> P["Planner candidate cards"]
  W --> R["Compare runner card"]
  HS --> CD["Cost-details popover<br/>(self + prerequisite rows)"]
```

Stepping writes through the same `onHintLevelChange` action the popover used, so card and popover stay in sync by construction.

## What's here

- **skill-item/hint-stepper.tsx** — `HintLevelStepper` (controlled − / + control, 0–5, fixed-width value cell showing level + discount) and `SkillItemHintStepper` (reads the SkillItem context; renders nothing for cost-less/unique or obtained skills).
- **skill-planner/hint-levels.ts** — single source for hint→discount (was duplicated in 4 places: cost-calculator, cost-details Select, stepper, HelpDialog). Data-free on purpose so workers/UI don't drag in the dataset.
- **CandidateSkillList.tsx / runner-card/skill-row.tsx** — steppers wired into planner candidate cards and the compare runner card. Runner card rows now mirror the planner composition (identity + actions on top, stepper + cost sharing the bottom row).
- **cost-details.tsx** — the three hint Selects (self + prereq rows) replaced with the stepper; prereq rows step their own skill id.
- **HelpDialog.tsx** — hint table rows derived from the shared data instead of hardcoded.

## UX details

- Discount hidden at level 0 ("No hint"); value cell fixed at 88px (widest state "Lv Max 40%") so the control never resizes while stepping.
- Buttons disable at bounds; `aria-label`s on both; group `title` announces "Hint Lv 3 · 30% off".
- Discount color is AA-safe per theme: light `--primary` (#66bf0d) only clears ~2.3:1 at this size, so light mode uses a deeper green (≥5:1); dark keeps theme primary.

## Gates

typecheck ✅ · lint 0 errors · 64 tests ✅ · verified live in-browser: card↔popover two-way sync, cost recalculation (170→153→136 SP), bounds, both themes, no layout shift.
