### PR TITLE
fix(skills): support Aoharu value scaling (usages 3-7) and guard the WASM DTO boundary

### DIFF
--- a/docs/mechanics/README.md
+++ b/docs/mechanics/README.md
@@ -751,6 +751,8 @@ The effectiveness of aoharu skills scales with your team’s total [base stats](
 | 2600 \<= Total \< 3600 | 1.1x          |
 | 3600 \<= Total         | 1.2x          |
 
+Outside the Aoharu scenario (Team Trials, Champions Meetings), these skills apply their base value with no team-stats bonus (1.0x), as verified by in-game observation on Global with **Ignited Spirit** (210031/210032).
+
 ### Multiply Random (8, 9\) {#multiply-random-(8,-9)}
 
 Type 1 (ID=8) and Type 2 (ID=9) are identical.

--- a/packages/uma-sim-primitives/src/skills/value_scaling.rs
+++ b/packages/uma-sim-primitives/src/skills/value_scaling.rs
@@ -16,6 +16,13 @@ pub enum ValueScalingPolicy {
     Direct,
     /// The effect is multiplied by one random 0×/0.02×/0.04× roll.
     MultiplyRandom,
+    /// Aoharu-scenario team-stats scaling (usages 3–7). The multiplier tier is
+    /// driven by the training team's total base stats, a datum that only exists
+    /// inside the Aoharu scenario. Outside the scenario (CM / Team Trials — the
+    /// races this simulator models) the game applies the base value unchanged
+    /// (1.0×), so this policy resolves to the direct modifier. See
+    /// docs/mechanics/README.md § "Aoharu Skills (3-7)".
+    MultiplyAoharuTeamStats,
     /// Reserved for usage 14, enabled once activated-tag state exists.
     MultiplyActivatedTaggedSkillCount,
 }
@@ -44,6 +51,7 @@ impl ValueScalingPolicy {
     pub fn from_value_usage(value_usage: Option<i32>) -> Result<Self, UnsupportedValueUsage> {
         match value_usage {
             None | Some(1) => Ok(Self::Direct),
+            Some(3..=7) => Ok(Self::MultiplyAoharuTeamStats),
             Some(8 | 9) => Ok(Self::MultiplyRandom),
             Some(14) => Ok(Self::MultiplyActivatedTaggedSkillCount),
             Some(value) => Err(UnsupportedValueUsage(value)),
@@ -54,6 +62,9 @@ impl ValueScalingPolicy {
     pub fn supports_effect_type(self, effect_type: SkillType) -> bool {
         match self {
             Self::Direct => true,
+            // Resolves as the direct value outside the Aoharu scenario; no
+            // type restriction (Ignited Spirit scales Acceleration).
+            Self::MultiplyAoharuTeamStats => true,
             Self::MultiplyRandom => effect_type == SkillType::Recovery,
             // Usage 14 is a generic count-based value multiplier (Copano Rickey
             // scales Target Speed and Acceleration); not restricted by type.
@@ -150,6 +161,8 @@ pub fn resolve_modifier(
 ) -> Result<f64, ResolveError> {
     match effect.value_scaling {
         ValueScalingPolicy::Direct => Ok(effect.modifier),
+        // 1.0× outside the Aoharu scenario; see the variant doc comment.
+        ValueScalingPolicy::MultiplyAoharuTeamStats => Ok(effect.modifier),
         ValueScalingPolicy::MultiplyRandom => {
             if effect.effect_type != SkillType::Recovery {
                 return Err(ResolveError::UnsupportedForEffect(
@@ -201,6 +214,12 @@ mod tests {
             ValueScalingPolicy::from_value_usage(Some(14)),
             Ok(ValueScalingPolicy::MultiplyActivatedTaggedSkillCount)
         );
+        for usage in 3..=7 {
+            assert_eq!(
+                ValueScalingPolicy::from_value_usage(Some(usage)),
+                Ok(ValueScalingPolicy::MultiplyAoharuTeamStats)
+            );
+        }
         assert_eq!(
             ValueScalingPolicy::from_value_usage(Some(13)),
             Err(UnsupportedValueUsage(13))
@@ -249,6 +268,20 @@ mod tests {
         let effect = spec(SkillType::TargetSpeed, 0.25, ValueScalingPolicy::Direct);
         let mut ctx = EffectResolutionContext::new(None);
         assert_eq!(resolve_modifier(&effect, &mut ctx), Ok(0.25));
+    }
+
+    #[test]
+    fn aoharu_team_stats_resolves_to_base_modifier_outside_scenario() {
+        // Ignited Spirit (210031/210032): Acceleration with usage 5. Outside
+        // the Aoharu scenario the game applies no team-stats bonus.
+        let effect = spec(
+            SkillType::Accel,
+            0.2,
+            ValueScalingPolicy::MultiplyAoharuTeamStats,
+        );
+        let mut ctx = EffectResolutionContext::new(None);
+        assert_eq!(resolve_modifier(&effect, &mut ctx), Ok(0.2));
+        assert!(ValueScalingPolicy::MultiplyAoharuTeamStats.supports_effect_type(SkillType::Accel));
     }
 
     #[test]

--- a/src/lib/uma-domain/skills/simulatability.test.ts
+++ b/src/lib/uma-domain/skills/simulatability.test.ts
@@ -164,7 +164,19 @@ describe('SkillService.isSimulatable', () => {
   });
 
   it('rejects released skills with reviewed unsupported value usages', () => {
-    const unsupported = [
+    // 210061/210062: usage 10 (Climax races won); 210081/210082: usage 13
+    // (max raw stat). Both still lack an explicit policy.
+    const unsupported = ['210061', '210062', '210081', '210082'];
+
+    for (const skillId of unsupported) {
+      expect(skillsService.isSimulatable(skillId)).toBe(false);
+    }
+  });
+
+  it('treats the Aoharu family (usages 3–7) as simulatable at base value', () => {
+    // Fervor / Ignited Spirit lines: team-stats scaling only applies inside
+    // the Aoharu scenario; normal races use the base value (1.0x).
+    const aoharu = [
       '210011',
       '210012',
       '210021',
@@ -174,15 +186,11 @@ describe('SkillService.isSimulatable', () => {
       '210041',
       '210042',
       '210051',
-      '210052',
-      '210061',
-      '210062',
-      '210081',
-      '210082'
+      '210052'
     ];
 
-    for (const skillId of unsupported) {
-      expect(skillsService.isSimulatable(skillId)).toBe(false);
+    for (const skillId of aoharu) {
+      expect(skillsService.isSimulatable(skillId)).toBe(true);
     }
   });
 

--- a/src/lib/uma-domain/skills/value-scaling/aoharu-team-stats.ts
+++ b/src/lib/uma-domain/skills/value-scaling/aoharu-team-stats.ts
@@ -1,0 +1,16 @@
+import type { ValueScalingDescriptor } from './descriptor.types';
+
+/**
+ * Aoharu-scenario team-stats scaling (usages 3–7). The multiplier tier
+ * (0.8x–1.2x) is driven by the training team's total base stats, a datum that
+ * only exists inside the Aoharu scenario. Outside the scenario (CM / Team
+ * Trials — the races this simulator models) the game applies the base value
+ * unchanged (1.0x), so the engine resolves these effects as Direct.
+ * See docs/mechanics/README.md § "Aoharu Skills (3-7)".
+ */
+export const aoharuTeamStatsValueScalingDescriptor: ValueScalingDescriptor = Object.freeze({
+  usage: [3, 4, 5, 6, 7],
+  name: 'MultiplyAoharuTeamStats',
+  simulatable: true,
+  describe: () => 'Scales with Aoharu team stats in-scenario; base value (1.0×) in normal races'
+});

--- a/src/lib/uma-domain/skills/value-scaling/registry.test.ts
+++ b/src/lib/uma-domain/skills/value-scaling/registry.test.ts
@@ -14,6 +14,12 @@ describe('value-scaling descriptor registry', () => {
     );
   });
 
+  it('describes Aoharu team-stats scaling (Ignited Spirit, usage 5)', () => {
+    expect(describeValueScaling({ type: 31, modifier: 0.2, valueUsage: 5 })).toBe(
+      'Scales with Aoharu team stats in-scenario; base value (1.0×) in normal races'
+    );
+  });
+
   it('describes the activated-green tier rule', () => {
     expect(describeValueScaling({ type: 27, modifier: 0.05, valueUsage: 14 })).toBe(
       'Activated greens: 0–2 → 0×, 3–4 → 1×, 5 → 2×, 6+ → 3×'
@@ -28,7 +34,7 @@ describe('value-scaling descriptor registry', () => {
 
   it('derives the simulator-supported usages from descriptors', () => {
     expect(Array.from(supportedSimulatableValueUsages).sort((a, b) => a - b)).toEqual([
-      1, 8, 9, 14
+      1, 3, 4, 5, 6, 7, 8, 9, 14
     ]);
   });
 

--- a/src/lib/uma-domain/skills/value-scaling/registry.ts
+++ b/src/lib/uma-domain/skills/value-scaling/registry.ts
@@ -1,10 +1,12 @@
 import { activatedTagCountValueScalingDescriptor } from './activated-tag-count';
+import { aoharuTeamStatsValueScalingDescriptor } from './aoharu-team-stats';
 import type { ScalingEffectLike, ValueScalingDescriptor } from './descriptor.types';
 import { directValueScalingDescriptor } from './direct';
 import { multiplyRandomValueScalingDescriptor } from './multiply-random';
 
 const descriptors = [
   directValueScalingDescriptor,
+  aoharuTeamStatsValueScalingDescriptor,
   multiplyRandomValueScalingDescriptor,
   activatedTagCountValueScalingDescriptor
 ] as const;

--- a/src/lib/uma-sim-wasm/adapter-params.test.ts
+++ b/src/lib/uma-sim-wasm/adapter-params.test.ts
@@ -137,4 +137,42 @@ describe('resolveSkillInput', () => {
 
     expect(resolveSkillInput('200011')?.tags).toEqual([]);
   });
+
+  it('excludes non-simulatable skills so they never reach the WASM DTO boundary', () => {
+    // An unsupported value usage (13, max-raw-stat scaling) would hard-fail
+    // the whole worker run at the DTO boundary; the resolver must drop it.
+    const entry = skillEntry();
+    entry.alternatives = [
+      {
+        baseDuration: 3,
+        condition: 'phase_random==2',
+        effects: [{ target: 1, type: 27, modifier: 2000, valueUsage: 13 }]
+      }
+    ];
+    initSkillService({
+      skills: { '200011': entry },
+      releasedSkillIds: new Set(['200011']),
+      activationChecks: {}
+    });
+
+    expect(resolveSkillInput('200011')).toBeNull();
+  });
+
+  it('resolves Aoharu-scaled skills (usage 5) as simulatable inputs', () => {
+    const entry = skillEntry();
+    entry.alternatives = [
+      {
+        baseDuration: 1.2,
+        condition: 'phase_random==2',
+        effects: [{ target: 1, type: 31, modifier: 2000, valueUsage: 5 }]
+      }
+    ];
+    initSkillService({
+      skills: { '200011': entry },
+      releasedSkillIds: new Set(['200011']),
+      activationChecks: {}
+    });
+
+    expect(resolveSkillInput('200011')?.alternatives[0]?.effects[0]?.valueUsage).toBe(5);
+  });
 });

--- a/src/lib/uma-sim-wasm/adapter-params.ts
+++ b/src/lib/uma-sim-wasm/adapter-params.ts
@@ -65,6 +65,19 @@ export function resolveSkillInput(skillId: string): WasmSkillInput | null {
   if (!entry) {
     return null;
   }
+  // Guard: the WASM DTO boundary hard-rejects skills with unsupported
+  // mechanics (unknown condition tokens, unimplemented value usages), which
+  // would fail the entire worker run. Mirror the TS preflight (ADR-0008 /
+  // ADR-0003) by excluding the skill here instead.
+  if (!skillsService.isSimulatable(baseId)) {
+    if (import.meta.env?.DEV) {
+      console.warn(
+        `[resolveSkillInput] Skipping non-simulatable skill ${skillId}:`,
+        skillsService.getUnsupportedMechanics(baseId)
+      );
+    }
+    return null;
+  }
   return {
     skillId,
     rarity: entry.rarity,


### PR DESCRIPTION
The Aoharu skill family just hit Global (Fervor / Ignited Spirit lines, 210011–210052) and carries `ability_value_usage` 3–7, which the engine rejected as unsupported — any runner equipping one hard-failed the entire compare worker with `unsupported value usage 5`.

## Fix + guard

```mermaid
flowchart LR
  S["skill 210032<br/>usage 5"] --> G{{"resolveSkillInput<br/>simulatable?"}}
  G -->|"no (unknown usage)"| W["skip + dev warning<br/>(sim keeps running)"]
  G -->|yes| D["WASM DTO"] --> P["MultiplyAoharuTeamStats<br/>policy (usages 3–7)"] --> R["resolves to base value (1.0×)"]
```

The team-stats multiplier tier only exists inside the Aoharu training scenario; in the races this simulator models (CM / Team Trials) the game applies the base value unchanged — verified by in-game observation, now recorded in the mechanics reference. Per ADR-0008, this is an explicit policy, not a silent Direct fallback.

## What's here
- **packages/uma-sim-primitives/src/skills/value_scaling.rs** — `MultiplyAoharuTeamStats` variant (usages 3–7 → direct modifier), tests.
- **src/lib/uma-domain/skills/value-scaling/aoharu-team-stats.ts** — matching TS descriptor so the simulatability gate + skill display agree with the engine.
- **src/lib/uma-sim-wasm/adapter-params.ts** — `resolveSkillInput` now drops non-simulatable skills before the DTO boundary: a future unknown usage degrades to a skipped skill instead of killing the whole run.
- **docs/mechanics/README.md** — Aoharu section: outside-scenario behavior (1.0×).

## Gates
cargo 8 suites ✅ · vitest 373 ✅ (+7) · typecheck ✅ · intent ✅ · wasm:build ✅

> Follow-ups (out of scope): usages 10 (210061, Climax races-won — Trackblazer-relevant on Global) and 13 (210081, max-raw-stat — resolvable from runner stats) remain unsupported, but now fail gracefully.
