### PR TITLE
fix(race-sim): exclude teammates from external debuff effects

### DIFF
--- a/packages/uma-sim-primitives/src/mob.rs
+++ b/packages/uma-sim-primitives/src/mob.rs
@@ -37,6 +37,7 @@ fn mob_runner(index: usize, strategy: Strategy, stats: i32) -> CreateRunner {
         mood: Mood::Normal,
         strategy,
         popularity: 0,
+        team: None,
         aptitudes: RunnerAptitudes {
             distance: Aptitude::A,
             strategy: Aptitude::A,

--- a/packages/uma-sim-primitives/src/runner/lifecycle.rs
+++ b/packages/uma-sim-primitives/src/runner/lifecycle.rs
@@ -63,6 +63,10 @@ pub struct CreateRunner {
     pub strategy: Strategy,
     /// Betting popularity rank (1 = most popular). `0` means unknown/unset.
     pub popularity: i64,
+    /// CM/LoH team grouping (1-based). `None` = no team. Teammates can trigger
+    /// and be targeted by skills, but are excluded from the *effect* of
+    /// external debuffs (mechanics § Skill Target).
+    pub team: Option<i32>,
     /// Aptitudes.
     pub aptitudes: RunnerAptitudes,
     /// Raw input stats.
@@ -143,6 +147,7 @@ impl Runner {
             position_keep_strategy: props.strategy,
             mood: props.mood,
             popularity: props.popularity,
+            team: props.team,
             aptitudes: props.aptitudes,
             stats: props.stats,
             base_stats,
@@ -416,6 +421,7 @@ mod tests {
             mood: Mood::Great,
             strategy,
             popularity: 0,
+            team: None,
             aptitudes: RunnerAptitudes {
                 distance: Aptitude::A,
                 strategy: Aptitude::A,

--- a/packages/uma-sim-primitives/src/runner/mod.rs
+++ b/packages/uma-sim-primitives/src/runner/mod.rs
@@ -121,6 +121,9 @@ pub struct Runner {
     /// Betting popularity rank (1 = most popular). `0` means unknown/unset.
     /// Static for the race; read by the `popularity` skill condition.
     pub popularity: i64,
+    /// CM/LoH team grouping (1-based). `None` = no team. Read by the external
+    /// debuff coordinator: teammates are excluded from debuff effects.
+    pub team: Option<i32>,
     /// Distance / strategy / surface aptitudes.
     pub aptitudes: RunnerAptitudes,
     /// Raw input stats (pre-adjustment).
@@ -560,6 +563,7 @@ pub mod test_support {
             mood: Mood::Normal,
             strategy,
             popularity: 0,
+            team: None,
             aptitudes: RunnerAptitudes {
                 distance: Aptitude::A,
                 strategy: Aptitude::A,

--- a/packages/uma-sim-primitives/src/runner/skills.rs
+++ b/packages/uma-sim-primitives/src/runner/skills.rs
@@ -1244,6 +1244,7 @@ mod tests {
             mood: Mood::Normal,
             strategy: Strategy::PaceChaser,
             popularity: 0,
+            team: None,
             aptitudes: RunnerAptitudes {
                 distance: Aptitude::A,
                 strategy: Aptitude::A,
@@ -1461,6 +1462,7 @@ mod tests {
             mood: Mood::Normal,
             strategy: Strategy::PaceChaser,
             popularity: 0,
+            team: None,
             aptitudes: RunnerAptitudes {
                 distance: Aptitude::S,
                 strategy: Aptitude::A,

--- a/packages/uma-sim-race/src/race.rs
+++ b/packages/uma-sim-race/src/race.rs
@@ -416,6 +416,7 @@ impl Race {
         struct Route {
             target: RunnerId,
             source: RunnerId,
+            source_team: Option<i32>,
             skill_id: uma_sim_primitives::shared_kernel::ids::SkillId,
             effect: uma_sim_primitives::skills::model::ResolvedSkillEffect,
         }
@@ -425,6 +426,7 @@ impl Race {
                 continue;
             }
             let source = runner.id;
+            let source_team = runner.team;
             let emitted = std::mem::take(&mut runner.emitted_debuffs);
             for debuff in emitted {
                 let targets =
@@ -433,6 +435,7 @@ impl Race {
                     routes.push(Route {
                         target,
                         source,
+                        source_team,
                         skill_id: debuff.skill_id.clone(),
                         effect: debuff.effect,
                     });
@@ -441,8 +444,15 @@ impl Race {
         }
 
         // Phase 2: apply onto each target via the targeted-effect path.
+        // Teammates stay valid *targets* (they count toward a skill's maximum
+        // target in-game) but are excluded from the debuff *effect*
+        // (docs/mechanics/README.md § Skill Target), so the exclusion happens
+        // here at application, after target resolution.
         for route in routes {
             if let Some(target) = self.runners.iter_mut().find(|r| r.id == route.target) {
+                if route.source_team.is_some() && route.source_team == target.team {
+                    continue;
+                }
                 target.receive_targeted_effect(
                     route.skill_id,
                     vec![route.effect],
@@ -884,6 +894,7 @@ mod tests {
             mood: Mood::Normal,
             strategy,
             popularity: 0,
+            team: None,
             aptitudes: RunnerAptitudes {
                 distance: Aptitude::A,
                 strategy: Aptitude::A,
@@ -1089,6 +1100,65 @@ mod tests {
             race.runners[1].used_targeted_skills[0].skill_id.as_str(),
             "200851"
         );
+    }
+
+    #[test]
+    fn external_debuff_skips_same_team_targets() {
+        use uma_sim_primitives::race_support::build_field_snapshot;
+        use uma_sim_primitives::shared_kernel::ids::SkillId;
+        use uma_sim_primitives::skills::effect::{SkillTarget, SkillType};
+        use uma_sim_primitives::skills::model::{EmittedDebuff, ResolvedSkillEffect};
+
+        // R0 caster (team 1), R1 Front Runner teammate (team 1), R2 Front
+        // Runner opponent (team 2), R3 Front Runner without a team.
+        let mut race = Race::new(
+            test_course(),
+            GroundCondition::Firm,
+            SimulationSettings::default(),
+            test_race_params(),
+        );
+        let mut caster = props("caster", Strategy::LateSurger);
+        caster.team = Some(1);
+        let mut teammate = props("teammate", Strategy::FrontRunner);
+        teammate.team = Some(1);
+        let mut opponent = props("opponent", Strategy::FrontRunner);
+        opponent.team = Some(2);
+        let teamless = props("teamless", Strategy::FrontRunner);
+        race.add_runner(caster);
+        race.add_runner(teammate);
+        race.add_runner(opponent);
+        race.add_runner(teamless);
+        race.prepare_round(7);
+
+        let snapshot = build_field_snapshot(
+            &mut race.runners,
+            &race.finished_runners,
+            &mut race.order_tracker,
+        );
+
+        race.runners[0].emitted_debuffs.push(EmittedDebuff {
+            skill_id: SkillId::new("200851"),
+            effect: ResolvedSkillEffect {
+                target: SkillTarget::EnemyStrategy,
+                effect_type: SkillType::CurrentSpeed,
+                base_duration: 3.0,
+                modifier: -0.15,
+            },
+            target: SkillTarget::EnemyStrategy,
+            target_strategy: Some(Strategy::FrontRunner),
+        });
+
+        race.coordinate_external_debuffs(&snapshot);
+
+        // Teammates are excluded from the effect of debuffs (mechanics § Skill
+        // Target): the same-team front runner is untouched, while the enemy
+        // team and teamless front runners are both hit.
+        assert!(race.runners[1].targeted_current_speed_active.is_empty());
+        assert!(race.runners[1].used_targeted_skills.is_empty());
+        assert_eq!(race.runners[2].targeted_current_speed_active.len(), 1);
+        assert!(race.runners[2].modifiers.current_speed.total() < 0.0);
+        assert_eq!(race.runners[3].targeted_current_speed_active.len(), 1);
+        assert!(race.runners[3].modifiers.current_speed.total() < 0.0);
     }
 
     #[test]

--- a/packages/uma-sim-race/src/simulation.rs
+++ b/packages/uma-sim-race/src/simulation.rs
@@ -286,6 +286,7 @@ mod tests {
             mood: Mood::Normal,
             strategy,
             popularity: 0,
+            team: None,
             aptitudes: RunnerAptitudes {
                 distance: Aptitude::A,
                 strategy: Aptitude::A,

--- a/packages/uma-sim-vacuum/src/race.rs
+++ b/packages/uma-sim-vacuum/src/race.rs
@@ -441,6 +441,7 @@ mod tests {
             mood: Mood::Normal,
             strategy,
             popularity: 0,
+            team: None,
             aptitudes: RunnerAptitudes {
                 distance: Aptitude::A,
                 strategy: Aptitude::A,

--- a/packages/uma-sim-wasm/src/dto.rs
+++ b/packages/uma-sim-wasm/src/dto.rs
@@ -600,6 +600,10 @@ pub struct WasmCreateRunner {
     /// Betting popularity rank (1 = most popular). `0`/omitted = unknown.
     #[serde(default)]
     pub popularity: i64,
+    /// CM/LoH team grouping (1-based). Omitted/`null` = no team. Must stay
+    /// `Option` so a present-but-`undefined` key deserializes to `None`.
+    #[serde(default)]
+    pub team: Option<i32>,
     /// Aptitudes.
     pub aptitudes: WasmAptitudes,
     /// Raw stats.
@@ -635,6 +639,7 @@ impl WasmCreateRunner {
             mood: to_mood(self.mood)?,
             strategy: to_strategy(self.strategy)?,
             popularity: self.popularity,
+            team: self.team,
             aptitudes: self.aptitudes.into_domain()?,
             stats: self.stats.into(),
             skills: self

--- a/src/lib/uma-domain/runner/types.ts
+++ b/src/lib/uma-domain/runner/types.ts
@@ -23,6 +23,8 @@ export type CreateRunner = {
   skills: Array<string>;
   gate?: number;
   popularity?: number;
+  /** CM/LoH team grouping (1-based); teammates are excluded from debuff effects. */
+  team?: number;
   forcedPositions?: Record<string, number>;
   injectedDebuffs?: Array<{ skillId: string; position: number }>;
   forcedRushedRegions?: Array<{ start: number; end: number }>;

--- a/src/lib/uma-sim-wasm/adapter-params.ts
+++ b/src/lib/uma-sim-wasm/adapter-params.ts
@@ -131,6 +131,7 @@ export function sundayRunnerToWasm(runner: CreateRunner, name: string): WasmCrea
     mood: runner.mood,
     strategy: runner.strategy,
     popularity: runner.popularity ?? 0,
+    team: runner.team,
     aptitudes: runner.aptitudes,
     stats: runner.stats,
     skills,

--- a/src/lib/uma-sim-wasm/types.ts
+++ b/src/lib/uma-sim-wasm/types.ts
@@ -74,6 +74,7 @@ export type WasmCreateRunner = {
   mood: number; // -2..2
   strategy: number; // 1 front, 2 pace, 3 late, 4 end, 5 runaway
   popularity?: number; // betting rank (1 = most popular); 0/omitted = unknown
+  team?: number; // CM/LoH team grouping (1-based); omitted = no team
   aptitudes: WasmAptitudes;
   stats: WasmStatLine;
   skills?: WasmSkillInput[];

--- a/src/modules/simulation/simulators/shared-pure.ts
+++ b/src/modules/simulation/simulators/shared-pure.ts
@@ -100,6 +100,8 @@ export function toCreateRunner(
     skills: sortedSkills,
     // IRunnerState.gate is the 1-based post; the engine expects a 0-based gate.
     gate: typeof runner.gate === 'number' ? runner.gate - 1 : undefined,
+    // CM/LoH team grouping: teammates are excluded from debuff effects.
+    team: typeof runner.team === 'number' ? runner.team : undefined,
     forcedPositions,
     injectedDebuffs: injectedDebuffs?.map(({ skillId, position }) => ({ skillId, position })),
     forcedRushedRegions: scenarioOverrides?.forcedRushed


### PR DESCRIPTION
Stacked on #68. Runners on the same CM/LoH team were hit by each other's debuffs (reported: Eishin Flash's Hesitant Front Runners debuffing its own Team 1 front runners). Per the mechanics reference (§ Skill Target): teammates can trigger and be targeted by skills — and count toward a skill's maximum target — but are **excluded from the effect** of debuffs.

## Routing

```mermaid
flowchart LR
  UI["IRunnerState.team<br/>(1-based, optional)"] --> CR["CreateRunner"] --> DTO["WasmCreateRunner<br/>team: Option&lt;i32&gt;"] --> RN["Runner.team"]
  RN --> C{{"coordinate_external_debuffs<br/>apply effect?"}}
  C -->|"same team"| X["skip (still a valid target)"]
  C -->|"enemy / teamless"| E["receive_targeted_effect"]
```

The exclusion happens at effect *application*, after target resolution — preserving targeting semantics (max-target counting) for when the engine models caps.

## What's here
- **packages/uma-sim-race/src/race.rs** — same-team skip in the external-debuff coordinator; regression test (teammate untouched, enemy-team + teamless both hit).
- **packages/uma-sim-primitives** (`lifecycle.rs`, `mod.rs`, `mob.rs`) — `team: Option<i32>` on `CreateRunner`/`Runner`; mobs are teamless.
- **packages/uma-sim-wasm/src/dto.rs** — `team` DTO field, kept `Option` per the present-but-`undefined` serde rule.
- **src/lib/uma-domain/runner/types.ts, src/modules/simulation/simulators/shared-pure.ts, src/lib/uma-sim-wasm/{types,adapter-params}.ts** — TS plumbing from the runner UI state to the boundary.

## Gates
cargo 8 suites ✅ (+1 test) · vitest 373 ✅ · typecheck ✅ · intent ✅ · wasm:build ✅

> Frenzied-style rushed-duration debuffs route through the same coordinator, so teammates are excluded there too. Runners without a team keep current behavior.
