### PR TITLE
feat(compare): reinstate opt-in vacuum compare mode for duo fields

### DIFF
--- a/.hiker/tents/contested-field/CONTEXT.md
+++ b/.hiker/tents/contested-field/CONTEXT.md
@@ -1,7 +1,6 @@
 # contested-field — intent context
 
-Compiled intent for the `contested-field` initiative (2–12 uma compare with
-pairwise A/B, C2 design). Check with:
+Compiled intent for the `contested-field` initiative (2–12 uma compare with pairwise A/B, C2 design). Check with:
 
 ```sh
 hiker check .hiker/tents/contested-field/contested-field.tent
@@ -15,28 +14,21 @@ hiker check .hiker/tents/contested-field/contested-field.tent
 | `race_sim_field_valid` | `run_race_sim` field is **exactly 9** | Raising the contested ceiling "unifies" both regimes and race-sim starts accepting 12 | `packages/uma-sim-race/src/simulation.rs` (`FIELD_SIZE`, `run_race_sim` validation) |
 | `contested_field_valid` | contested compare accepts **2..=12** | Ceiling silently stays 9 (validation not updated) or loses the floor of 2 | `run_contested_compare` validation, `MAX_CONTESTED_FIELD` |
 | `mob_fill_valid` | engine fill target ∈ `[runnerCount, 12]` | Padding below the real runner count, or past the engine ceiling | engine `fill_to` validation; TS `computeFillTo(runnerCount, fieldSize)` in `wasm-compare-plan.ts`. The user-facing `fieldSize` setting (compare.store, default 9 per the field-composition experiment) is clamped `[2, 12]`; fill mobs are flat 600-stat runners cycling the standard strategy mix (`mob.rs CONTESTED_FILL_MOB_STATS`, overridable via `mobStats` in the WASM params) |
-| `compare_flow_contested_only` | user-facing compare mode is always contested (`mode == 0`) | Reintroducing a vacuum/contested branch to the compare UI or runner orchestration | `compare.store.ts` (no mode state); `wasm-compare-plan.ts` and `wasm-compare.ts` contested-only plan/run path |
+| `vacuum_run_is_duo` | user-facing vacuum compare is **duo-only** (`fieldSize == 2`) | Allowing vacuum at field > 2, or treating vacuum as the default mode instead of an opt-in | `compare.store.ts` (`DEFAULT_COMPARE_MODE = 'contested'`, `canUseVacuum` / `forceContestedForField`); vacuum plan/run path in `wasm-compare-plan.ts` / `wasm-compare.ts` |
 | `pair_insertion_order` | Compare A at engine index 0, B at index 1 | Reordering runners in params silently swaps every pairwise stat (trace split keys on insertion order) | `contestedCompareParamsToWasm` callers; split at `wasm-compare.ts` (`splitContestedCompareRounds`) |
-| `legacy_snapshot_decode` | legacy/removed-vacuum shares ⇒ contested + 2-field | Importing old vacuum shares into a mob-filled field, hiding the closest surviving head-to-head analogue and warning path | `src/modules/simulation/share/snapshot.ts` version dispatch (`coercedFromVacuum`) |
+| `legacy_snapshot_decode` | legacy/pre-mode shares without compare mode ⇒ contested + 2-field | Importing old vacuum shares into a mob-filled field, hiding the closest surviving head-to-head analogue and warning path | `src/modules/simulation/share/snapshot.ts` version dispatch (`coercedFromVacuum`) |
 
-Mode encoding used by the sorts: `0 = contested`. The removed vacuum mode has no compare-flow encoding; batch vacuum engine paths remain only for planner/basin sims outside this intent.
+Mode encoding used by the store/UI: `0 = contested` (default), `1 = vacuum` (opt-in, duo-only). Contested remains the default compare mode; vacuum is reinstated as a user-facing toggle valid only when the field has exactly two runners. Hiker cannot express disjunction (`mode == 0 or (mode == 1 and fieldSize == 2)`), so vacuum duo-only is a `VacuumRun` sort/law and contested-default lives in store defaults plus docs. Batch vacuum engine paths also remain for planner/basin sims outside this intent.
 
 ## Expressiveness boundary
 
-- The `fieldSize` default of 9 and the "no padding when target ≤ runner count"
-  rule are not expressible (no arithmetic / defaults in laws); the laws pin the
-  **bounds** only. The exact mapping is covered by `computeFillTo` unit tests.
+- The `fieldSize` default of 9 and the "no padding when target ≤ runner count" rule are not expressible (no arithmetic / defaults in laws); the laws pin the **bounds** only. The exact mapping is covered by `computeFillTo` unit tests.
 - Mob stat level (600) is a default, not a law; covered by `mob.rs` unit tests.
-- `compareA !== compareB` (pair distinctness) is not expressible (no `!=`);
-  covered by runners.store unit tests.
-- Totality of the snapshot version dispatch (v2 / v1 / undefined) is not
-  expressible; covered by `snapshot.test.ts` legacy fixtures.
+- `compareA !== compareB` (pair distinctness) is not expressible (no `!=`); covered by runners.store unit tests.
+- Contested-as-default (`DEFAULT_COMPARE_MODE`) is not expressible as a law over mode without `or`; covered by compare.store unit tests and the vacuum duo law above.
+- Totality of the snapshot version dispatch (v2 / v1 / undefined) is not expressible; covered by `snapshot.test.ts` legacy fixtures.
 
 ## Enforcement
 
-- `hiker check` (this spec compiles) runs via the `intent` script:
-  `pnpm run intent`.
-- `gen` (property-test bridge) is deferred until the initiative's code exists:
-  the natural SUT functions are the TS-side validators (e.g. a
-  `contestedFieldValid(f)` predicate) once the store plan lands. Regenerate
-  into `.hiker-cache/` (gitignored), never commit generated tests.
+- `hiker check` (this spec compiles) runs via the `intent` script: `pnpm run intent`.
+- `gen` (property-test bridge) is deferred until the initiative's code exists: the natural SUT functions are the TS-side validators (e.g. a `contestedFieldValid(f)` predicate) once the store plan lands. Regenerate into `.hiker-cache/` (gitignored), never commit generated tests.

--- a/.hiker/tents/contested-field/contested-field.tent
+++ b/.hiker/tents/contested-field/contested-field.tent
@@ -2,8 +2,8 @@
 //
 // The collapse this prevents: an agent "unifying" the two field regimes
 // (race-sim's exact-9 and contested-compare's 2..=12) into one constant,
-// reintroducing a compare-mode branch to the user-facing flow, or reordering
-// the compare pair in engine params so the trace split silently swaps A and B.
+// silently making vacuum the default compare mode or allowing vacuum at field > 2,
+// or reordering the compare pair in engine params so the trace split silently swaps A and B.
 //
 // RaceSimField and ContestedField are deliberately DISTINCT sorts: a law
 // about one cannot be stated about the other, so "reuse the 9 check for
@@ -37,12 +37,16 @@ law mob_fill_valid(r) {
   r.fillTarget <= 12
 }
 
-// Compare mode: 0 = contested. The user-facing compare flow has no vacuum mode;
-// batch vacuum engine paths remain only for planner/basin sims outside this intent.
-sort CompareRun { fieldSize: Int, mode: Int }
-relation compare_flow_contested_only(run: CompareRun)
-law compare_flow_contested_only(run) {
-  run.mode == 0
+// Compare mode encoding (store/UI): 0 = contested (default), 1 = vacuum (opt-in).
+// Vacuum compare is a distinct sort so duo-only can be stated without disjunction;
+// contested field size stays on ContestedField (2..=12). Hiker has no `or`, so the
+// "contested default" half of the preferred disjunction is documentation + store
+// DEFAULT_COMPARE_MODE, not a law over CompareRun.mode.
+// Batch vacuum engine paths also remain for planner/basin sims outside this intent.
+sort VacuumRun { fieldSize: Int }
+relation vacuum_run_is_duo(r: VacuumRun)
+law vacuum_run_is_duo(r) {
+  r.fieldSize == 2
 }
 
 // Engine param ordering: Compare A is inserted first (index 0), B second

--- a/docs/adr/0007-contested-compare-use-case.md
+++ b/docs/adr/0007-contested-compare-use-case.md
@@ -16,6 +16,8 @@ Add contested compare as a separate use-case composition: run the existing `uma-
 
 > Amended by the contested-field initiative: the compared-runner ceiling was raised from 9 to 12 (`MAX_CONTESTED_FIELD`) and the boolean mob fill became a configurable `fill_to` target; `run_race_sim` remains exactly 9. Keep vacuum compare as the isolated paired-delta use case. The compare collector and DTO-shaped read-model types live in `uma-sim-primitives::compare` because they depend only on the observer/projection primitives and are valid for both engines.
 
+> Amended by the vacuum-compare-toggle initiative: vacuum compare is reinstated as an opt-in user-facing mode for duo fields (exactly two runners, no mobs); contested remains the default compare mode.
+
 This is not a mode flag inside formulas or the shared step kernel. Formula code stays field-agnostic; the difference remains at orchestration boundaries: vacuum compare synthesizes absent field inputs in `uma-sim-vacuum`, while contested compare obtains field inputs from a live `uma-sim-race` field and projects the same compare telemetry shape.
 
 ## Consequences

--- a/src/modules/runners/components/field-manager/field-manager-content.test.tsx
+++ b/src/modules/runners/components/field-manager/field-manager-content.test.tsx
@@ -7,6 +7,7 @@ import { FieldManagerContent } from './field-manager-content';
 import { useRunnersStore, MAX_RUNNERS, MIN_RUNNERS } from '@/store/runners.store';
 import {
   useRaceStore,
+  DEFAULT_COMPARE_MODE,
   DEFAULT_FIELD_SIZE,
   MIN_FIELD_SIZE
 } from '@/modules/simulation/stores/compare.store';
@@ -32,6 +33,7 @@ const resetStores = () => {
   localStorage.clear();
   seedField(2);
   useRaceStore.setState({
+    compareMode: DEFAULT_COMPARE_MODE,
     fieldSize: DEFAULT_FIELD_SIZE
   });
 };
@@ -93,10 +95,34 @@ describe('FieldManagerContent (manage mode)', () => {
     expect(state.compareB).toBe('r-1');
   });
 
-  it('does not render a compare mode control', () => {
+  it('hides the vacuum mode control at 3+ runners', () => {
+    seedField(2);
+    const { unmount } = render(<FieldManagerContent pickRole={null} onClose={() => {}} />);
+    expect(screen.getByRole('radiogroup', { name: /compare mode/i })).toBeInTheDocument();
+    unmount();
+
+    seedField(3);
+    render(<FieldManagerContent pickRole={null} onClose={() => {}} />);
+    expect(screen.queryByRole('radiogroup', { name: /compare mode/i })).not.toBeInTheDocument();
+  });
+
+  it('clicking Vacuum sets compare mode', () => {
+    seedField(2);
     render(<FieldManagerContent pickRole={null} onClose={() => {}} />);
 
-    expect(screen.queryByRole('radiogroup', { name: /compare mode/i })).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole('radio', { name: /^vacuum$/i }));
+
+    expect(useRaceStore.getState().compareMode).toBe('vacuum');
+  });
+
+  it('disables field-size controls in vacuum mode', () => {
+    seedField(2);
+    useRaceStore.setState({ compareMode: 'vacuum', fieldSize: DEFAULT_FIELD_SIZE });
+    render(<FieldManagerContent pickRole={null} onClose={() => {}} />);
+
+    expect(screen.getByRole('button', { name: /decrease field size/i })).toBeDisabled();
+    expect(screen.getByRole('button', { name: /increase field size/i })).toBeDisabled();
+    expect(screen.getByRole('spinbutton')).toBeDisabled();
   });
 
   it('steps the field size with the +/- controls and clamps at bounds', () => {
@@ -161,8 +187,6 @@ describe('FieldManagerContent (pick mode)', () => {
     render(<FieldManagerContent pickRole="uma1" onClose={() => {}} />);
 
     expect(screen.queryByRole('switch')).not.toBeInTheDocument();
-    expect(
-      screen.queryByRole('button', { name: /remove .* from field/i })
-    ).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /remove .* from field/i })).not.toBeInTheDocument();
   });
 });

--- a/src/modules/runners/components/field-manager/field-manager-content.tsx
+++ b/src/modules/runners/components/field-manager/field-manager-content.tsx
@@ -13,11 +13,14 @@ import {
   type FieldRunner
 } from '@/store/runners.store';
 import {
+  canUseVacuum,
   clampFieldSize,
+  setCompareMode,
   setFieldSize,
   useCompareSettings,
   MAX_FIELD_SIZE,
-  MIN_FIELD_SIZE
+  MIN_FIELD_SIZE,
+  type CompareMode
 } from '@/modules/simulation/stores/compare.store';
 import { getUmaDisplayInfo, getUmaImageUrl } from '@/modules/runners/utils';
 import { Button } from '@/components/ui/button';
@@ -101,7 +104,7 @@ export function FieldManagerContent(props: FieldManagerContentProps) {
 
   const runners = useRunners();
   const { compareA, compareB } = useCompareRoles();
-  const { fieldSize } = useCompareSettings();
+  const { compareMode, fieldSize } = useCompareSettings();
 
   const roleOf = (fieldId: string): CompareRole | null => {
     if (fieldId === compareA) return 'uma1';
@@ -270,7 +273,7 @@ export function FieldManagerContent(props: FieldManagerContentProps) {
                 variant="outline"
                 size="icon"
                 aria-label="Decrease field size"
-                disabled={fieldSize <= MIN_FIELD_SIZE}
+                disabled={compareMode === 'vacuum' || fieldSize <= MIN_FIELD_SIZE}
                 onClick={() => setFieldSize(fieldSize - 1)}
               >
                 <Minus className="size-3.5" />
@@ -282,6 +285,7 @@ export function FieldManagerContent(props: FieldManagerContentProps) {
                 min={MIN_FIELD_SIZE}
                 max={MAX_FIELD_SIZE}
                 value={fieldSize}
+                disabled={compareMode === 'vacuum'}
                 onChange={(e) => {
                   const value = Number.parseInt(e.target.value, 10);
                   if (Number.isFinite(value)) setFieldSize(clampFieldSize(value));
@@ -292,13 +296,54 @@ export function FieldManagerContent(props: FieldManagerContentProps) {
                 variant="outline"
                 size="icon"
                 aria-label="Increase field size"
-                disabled={fieldSize >= MAX_FIELD_SIZE}
+                disabled={compareMode === 'vacuum' || fieldSize >= MAX_FIELD_SIZE}
                 onClick={() => setFieldSize(fieldSize + 1)}
               >
                 <Plus className="size-3.5" />
               </Button>
             </div>
           </div>
+
+          {canUseVacuum(runners.length) && (
+            <div className="flex items-center justify-between gap-3 px-1">
+              <div className="min-w-0">
+                <Label className="text-sm">Compare mode</Label>
+                <p className="text-xs text-muted-foreground">
+                  {compareMode === 'contested'
+                    ? 'Both umas race each other; contention emerges naturally.'
+                    : 'Each uma runs isolated; lowest-variance build comparison.'}
+                </p>
+              </div>
+              <div
+                role="radiogroup"
+                aria-label="Compare mode"
+                className="flex shrink-0 overflow-hidden rounded-md border"
+              >
+                {(
+                  [
+                    ['contested', 'Same race'],
+                    ['vacuum', 'Vacuum']
+                  ] as Array<[CompareMode, string]>
+                ).map(([mode, label]) => (
+                  <button
+                    key={mode}
+                    type="button"
+                    role="radio"
+                    aria-checked={compareMode === mode}
+                    onClick={() => setCompareMode(mode)}
+                    className={cn(
+                      'cursor-pointer px-3 py-1.5 text-xs font-medium transition-colors focus-visible:outline-2 focus-visible:outline-ring',
+                      compareMode === mode
+                        ? 'bg-primary text-primary-foreground'
+                        : 'bg-background text-muted-foreground hover:bg-muted'
+                    )}
+                  >
+                    {label}
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
         </div>
       )}
     </div>

--- a/src/modules/simulation/hooks/compare/useSimulationRunner.ts
+++ b/src/modules/simulation/hooks/compare/useSimulationRunner.ts
@@ -66,7 +66,7 @@ export function useSimulationRunner() {
 
   const { uma1: forcedUma1, uma2: forcedUma2 } = useForcedPositions();
   const { uma1: debuffsUma1, uma2: debuffsUma2 } = useDebuffs();
-  const { fieldSize } = useCompareSettings();
+  const { compareMode, fieldSize } = useCompareSettings();
   const scenarioOverrides = useScenarioOverrides();
 
   const webWorkerRef = useRef<Worker | null>(null);
@@ -167,7 +167,7 @@ export function useSimulationRunner() {
     // worker never touches the dataset.
     worker.postMessage({
       type: 'compare',
-      data: buildComparePlan(params, { fieldSize, contextRunners })
+      data: buildComparePlan(params, { mode: compareMode, fieldSize, contextRunners })
     });
   };
 
@@ -220,7 +220,7 @@ export function useSimulationRunner() {
 
     worker.postMessage({
       type: 'compare',
-      data: buildComparePlan(params, { fieldSize, contextRunners })
+      data: buildComparePlan(params, { mode: compareMode, fieldSize, contextRunners })
     });
   }
 

--- a/src/modules/simulation/share/compare-share-actions.ts
+++ b/src/modules/simulation/share/compare-share-actions.ts
@@ -35,7 +35,7 @@ export function downloadCompareResults(filename?: string): void {
       exportedAt: new Date().toISOString(),
       meta: {
         seed: race.seed,
-        compareMode: 'contested',
+        compareMode: race.compareMode,
         fieldSize: race.fieldSize,
         courseId: useSettingsStore.getState().courseId,
         samples: race.results.length
@@ -60,7 +60,7 @@ export function downloadCompareResults(filename?: string): void {
     const url = URL.createObjectURL(blob);
     const a = document.createElement('a');
     a.href = url;
-    a.download = filename ?? `umalator-results-contested-${race.seed ?? 'noseed'}.json`;
+    a.download = filename ?? `umalator-results-${race.compareMode}-${race.seed ?? 'noseed'}.json`;
     a.click();
     URL.revokeObjectURL(url);
     toast.success('Simulation results downloaded');
@@ -114,6 +114,7 @@ export function useCompareShareCardProps(): CompareShareCardProps | null {
       leadCompetitionStats: s.leadCompetitionStats,
       staminaStats: s.staminaStats,
       seed: s.seed,
+      compareMode: s.compareMode,
       fieldSize: s.fieldSize
     }))
   );
@@ -160,7 +161,10 @@ export function useCompareShareCardProps(): CompareShareCardProps | null {
     const imageUrl = getUmaImageUrl(runner.outfitId, runner.randomMobId);
     const skills = getSkillsForShareCard(runner.skills);
 
-    const compareSummary = `Same race · field of ${race.fieldSize}`;
+    const compareSummary =
+      race.compareMode === 'contested'
+        ? `Same race · field of ${race.fieldSize}`
+        : 'Vacuum · isolated runners';
     const raceSummary = `${getRaceSettingsSummaryLine(courseId, racedef)} · ${compareSummary}`;
 
     const statRows: CompareShareStatRow[] = [

--- a/src/modules/simulation/share/import-snapshot-dialog.tsx
+++ b/src/modules/simulation/share/import-snapshot-dialog.tsx
@@ -93,9 +93,11 @@ export function ImportSnapshotDialog({ open, onOpenChange }: ImportSnapshotDialo
   const uma2Name = preview ? runnerName(preview.runners[preview.compareB]) : '';
   const runnerCount = preview ? preview.runners.length : 0;
   const compareModeLabel = preview
-    ? `Same race (field of ${Math.max(preview.fieldSize, runnerCount)}, ${runnerCount} uma${
-        runnerCount === 1 ? '' : 's'
-      })`
+    ? preview.compareMode === 'contested'
+      ? `Same race (field of ${Math.max(preview.fieldSize, runnerCount)}, ${runnerCount} uma${
+          runnerCount === 1 ? '' : 's'
+        })`
+      : 'Vacuum (isolated)'
     : '';
 
   return (

--- a/src/modules/simulation/share/import-snapshot-dialog.tsx
+++ b/src/modules/simulation/share/import-snapshot-dialog.tsx
@@ -73,7 +73,7 @@ export function ImportSnapshotDialog({ open, onOpenChange }: ImportSnapshotDialo
     toast.success('Simulation settings loaded');
     if (preview.coercedFromVacuum) {
       toast.warning(
-        'This share was created with the removed vacuum mode. It was imported as a same-race head-to-head, so results will differ.'
+        'This share predates compare modes. It was imported as a same-race head-to-head, so results may differ from the original.'
       );
     }
     handleOpenChange(false);

--- a/src/modules/simulation/share/snapshot.test.ts
+++ b/src/modules/simulation/share/snapshot.test.ts
@@ -55,7 +55,7 @@ const legacyCommon = {
 };
 
 describe('parseSnapshotJson', () => {
-  it('round-trips a v2 snapshot (field + compare pair + fillWithMobs)', () => {
+  it('round-trips a contested v2 snapshot unchanged', () => {
     const parsed = parseSnapshotJson(
       JSON.stringify(
         snapshot({
@@ -74,6 +74,7 @@ describe('parseSnapshotJson', () => {
     expect(parsed?.compareB).toBe(2);
     expect(parsed?.compareMode).toBe('contested');
     expect(parsed?.fieldSize).toBe(12);
+    expect(parsed?.coercedFromVacuum).toBeUndefined();
   });
 
   it('maps older v2 snapshots carrying fillWithMobs to field sizes', () => {
@@ -88,12 +89,8 @@ describe('parseSnapshotJson', () => {
   });
 
   it('rejects v2 snapshots with out-of-range compare indices', () => {
-    expect(
-      parseSnapshotJson(JSON.stringify(snapshot({ compareA: 0, compareB: 5 })))
-    ).toBeNull();
-    expect(
-      parseSnapshotJson(JSON.stringify(snapshot({ compareA: 1, compareB: 1 })))
-    ).toBeNull();
+    expect(parseSnapshotJson(JSON.stringify(snapshot({ compareA: 0, compareB: 5 })))).toBeNull();
+    expect(parseSnapshotJson(JSON.stringify(snapshot({ compareA: 1, compareB: 1 })))).toBeNull();
   });
 
   it('rejects unknown / future snapshot versions', () => {
@@ -101,7 +98,7 @@ describe('parseSnapshotJson', () => {
     expect(parseSnapshotJson(JSON.stringify(future))).toBeNull();
   });
 
-  it('imports a v1 legacy snapshot as contested head-to-head with a coercion flag', () => {
+  it('preserves an explicit v1 contested mode', () => {
     const v1Mobs = {
       version: 1,
       ...legacyCommon,
@@ -115,14 +112,14 @@ describe('parseSnapshotJson', () => {
     expect(parsedMobs?.compareA).toBe(0);
     expect(parsedMobs?.compareB).toBe(1);
     expect(parsedMobs?.compareMode).toBe('contested');
-    expect(parsedMobs?.fieldSize).toBe(2);
-    expect(parsedMobs?.coercedFromVacuum).toBe(true);
+    expect(parsedMobs?.fieldSize).toBe(9);
+    expect(parsedMobs?.coercedFromVacuum).toBeUndefined();
 
     const v1Duo = { ...v1Mobs, fieldComposition: 'duo' };
     const parsedDuo = parseSnapshotJson(JSON.stringify(v1Duo));
     expect(parsedDuo?.compareMode).toBe('contested');
     expect(parsedDuo?.fieldSize).toBe(2);
-    expect(parsedDuo?.coercedFromVacuum).toBe(true);
+    expect(parsedDuo?.coercedFromVacuum).toBeUndefined();
   });
 
   it('imports a pre-versioned legacy snapshot as contested head-to-head with a coercion flag', () => {
@@ -141,7 +138,7 @@ describe('parseSnapshotJson', () => {
     expect(parsed?.coercedFromVacuum).toBe(true);
   });
 
-  it('coerces a v2 vacuum snapshot to contested head-to-head with a coercion flag', () => {
+  it('round-trips a vacuum snapshot and forces a duo field', () => {
     const parsed = parseSnapshotJson(
       JSON.stringify(
         snapshot({
@@ -150,6 +147,17 @@ describe('parseSnapshotJson', () => {
         })
       )
     );
+
+    expect(parsed?.compareMode).toBe('vacuum');
+    expect(parsed?.fieldSize).toBe(2);
+    expect(parsed?.coercedFromVacuum).toBeUndefined();
+  });
+
+  it('coerces a v2 snapshot without a mode to contested head-to-head', () => {
+    const legacy = snapshot() as unknown as Record<string, unknown>;
+    delete legacy.compareMode;
+
+    const parsed = parseSnapshotJson(JSON.stringify(legacy));
 
     expect(parsed?.compareMode).toBe('contested');
     expect(parsed?.fieldSize).toBe(2);

--- a/src/modules/simulation/share/snapshot.ts
+++ b/src/modules/simulation/share/snapshot.ts
@@ -7,7 +7,10 @@ import {
   DEFAULT_FIELD_SIZE,
   MIN_FIELD_SIZE,
   resetResults,
-  useRaceStore
+  setCompareMode,
+  setFieldSize,
+  useRaceStore,
+  type CompareMode
 } from '@/modules/simulation/stores/compare.store';
 import { useForcedPositionsStore } from '@/modules/simulation/stores/forced-positions.store';
 import { useScenarioOverridesStore } from '@/modules/simulation/stores/scenario-overrides.store';
@@ -48,7 +51,7 @@ function buildSnapshot(): SimulationSnapshot {
     racedef: cloneDeep(settings.racedef),
     seed: race.seed,
     nsamples: settings.nsamples,
-    compareMode: 'contested',
+    compareMode: race.compareMode,
     fieldSize: race.fieldSize,
     witVarianceSettings: cloneDeep(settings.witVarianceSettings),
     staminaDrainOverrides: cloneDeep(settings.staminaDrainOverrides),
@@ -96,6 +99,10 @@ function isRaceConditions(value: unknown): boolean {
     typeof value.time === 'number' &&
     typeof value.grade === 'number'
   );
+}
+
+function isCompareMode(value: unknown): value is CompareMode {
+  return value === 'contested' || value === 'vacuum';
 }
 
 function isWitVariance(value: unknown): boolean {
@@ -160,7 +167,8 @@ function parseCommonFields(
     seed: parsed.seed as number | null,
     nsamples: parsed.nsamples,
     witVarianceSettings: parsed.witVarianceSettings as SimulationSnapshot['witVarianceSettings'],
-    staminaDrainOverrides: parsed.staminaDrainOverrides as SimulationSnapshot['staminaDrainOverrides'],
+    staminaDrainOverrides:
+      parsed.staminaDrainOverrides as SimulationSnapshot['staminaDrainOverrides'],
     forcedPositions: {
       uma1: fp.uma1 as Record<string, number>,
       uma2: fp.uma2 as Record<string, number>
@@ -187,20 +195,24 @@ function parseV2(parsed: Record<string, unknown>): SimulationSnapshot | null {
   if (compareB < 0 || compareB >= runners.length) return null;
   if (compareA === compareB) return null;
 
-  const coercedFromVacuum = parsed.compareMode !== 'contested';
-  // Newer v2 snapshots carry `fieldSize`; older v2 snapshots carried
-  // `fillWithMobs: boolean` (pad-to-9 vs no padding). Removed vacuum shares
-  // decode to the closest surviving analogue: contested head-to-head with no
-  // mob fill.
-  const fieldSize = coercedFromVacuum
-    ? MIN_FIELD_SIZE
-    : typeof parsed.fieldSize === 'number'
-      ? clampFieldSize(parsed.fieldSize)
-      : typeof parsed.fillWithMobs === 'boolean'
-        ? parsed.fillWithMobs
-          ? DEFAULT_FIELD_SIZE
-          : MIN_FIELD_SIZE
-        : DEFAULT_FIELD_SIZE;
+  if (parsed.compareMode !== undefined && !isCompareMode(parsed.compareMode)) return null;
+
+  // v2 snapshots without `compareMode` predate the mode field, so import them as contested head-to-head with no mob fill and surface the compatibility warning. Explicit modes preserve their original behavior.
+  const coercedFromVacuum = parsed.compareMode === undefined;
+  const compareMode: CompareMode = isCompareMode(parsed.compareMode)
+    ? parsed.compareMode
+    : 'contested';
+  if (compareMode === 'vacuum' && runners.length !== MIN_FIELD_SIZE) return null;
+  const fieldSize =
+    compareMode === 'vacuum' || coercedFromVacuum
+      ? MIN_FIELD_SIZE
+      : typeof parsed.fieldSize === 'number'
+        ? clampFieldSize(parsed.fieldSize)
+        : typeof parsed.fillWithMobs === 'boolean'
+          ? parsed.fillWithMobs
+            ? DEFAULT_FIELD_SIZE
+            : MIN_FIELD_SIZE
+          : DEFAULT_FIELD_SIZE;
 
   return {
     version: SIMULATION_SNAPSHOT_VERSION,
@@ -208,7 +220,7 @@ function parseV2(parsed: Record<string, unknown>): SimulationSnapshot | null {
     runners,
     compareA,
     compareB,
-    compareMode: 'contested',
+    compareMode,
     coercedFromVacuum: coercedFromVacuum || undefined,
     fieldSize
   };
@@ -219,22 +231,30 @@ function parseLegacyPair(parsed: Record<string, unknown>): SimulationSnapshot | 
   const common = parseCommonFields(parsed);
   if (!common) return null;
   if (!isRunnerState(parsed.uma1)) return null;
+  if (parsed.compareMode !== undefined && !isCompareMode(parsed.compareMode)) return null;
 
   const uma1 = parsed.uma1 as IRunnerState;
   const uma2 = isRunnerState(parsed.uma2) ? (parsed.uma2 as IRunnerState) : createRunnerState();
 
-  // Pair-shape snapshots predate the contested-only compare flow. Import them
-  // as contested head-to-head with no mob fill and warn that results differ
-  // from the removed vacuum mode.
+  // Pair snapshots without `compareMode` predate the mode field. Preserve explicit v1 modes; legacy pre-mode pairs become contested duo shares.
+  const coercedFromVacuum = parsed.compareMode === undefined;
+  const compareMode: CompareMode = isCompareMode(parsed.compareMode)
+    ? parsed.compareMode
+    : 'contested';
+  const fieldSize =
+    compareMode === 'vacuum' || coercedFromVacuum || parsed.fieldComposition === 'duo'
+      ? MIN_FIELD_SIZE
+      : DEFAULT_FIELD_SIZE;
+
   return {
     version: SIMULATION_SNAPSHOT_VERSION,
     ...common,
     runners: [uma1, uma2],
     compareA: 0,
     compareB: 1,
-    compareMode: 'contested',
-    coercedFromVacuum: true,
-    fieldSize: MIN_FIELD_SIZE
+    compareMode,
+    coercedFromVacuum: coercedFromVacuum || undefined,
+    fieldSize
   };
 }
 
@@ -289,9 +309,10 @@ export function importSnapshot(data: SimulationSnapshot): void {
 
   useRaceStore.setState({
     seed: data.seed,
-    fieldSize: clampFieldSize(data.fieldSize),
     injectedDebuffs: cloneDeep(data.injectedDebuffs)
   });
+  setFieldSize(data.compareMode === 'vacuum' ? MIN_FIELD_SIZE : data.fieldSize);
+  setCompareMode(data.compareMode);
 
   resetResults();
 }

--- a/src/modules/simulation/share/types.ts
+++ b/src/modules/simulation/share/types.ts
@@ -2,8 +2,7 @@ import type { IRunnerState } from '@/modules/runners/components/runner-card/type
 import type { WitVarianceSettings, StaminaDrainOverrides } from '@/store/settings.store';
 import type { RaceConditions } from '@/utils/races';
 import type { InjectedDebuffsMap, ScenarioOverridesMap } from '@/modules/simulation/types';
-
-type CompareMode = 'contested' | 'vacuum';
+import type { CompareMode } from '@/modules/simulation/stores/compare.store';
 
 export const SIMULATION_SNAPSHOT_VERSION = 2 as const;
 
@@ -27,7 +26,7 @@ export type SimulationSnapshot = {
   seed: number | null;
   nsamples: number;
   compareMode: CompareMode;
-  /** True when a legacy/vacuum share was coerced to contested + 2-field on decode. */
+  /** True when a legacy pre-mode snapshot was coerced to contested + 2-field on decode. */
   coercedFromVacuum?: boolean;
   /** Target field size (total gates); real umas fill first, mobs pad the rest. */
   fieldSize: number;

--- a/src/modules/simulation/simulators/wasm-compare-plan.ts
+++ b/src/modules/simulation/simulators/wasm-compare-plan.ts
@@ -5,17 +5,28 @@
 
 import type { CompareParams } from '@/modules/simulation/types';
 import type { IRunnerState } from '@/modules/runners/components/runner-card/types';
-import { contestedCompareParamsToWasm } from '@/lib/uma-sim-wasm/adapter-params';
+import {
+  compareParamsToWasm,
+  contestedCompareParamsToWasm
+} from '@/lib/uma-sim-wasm/adapter-params';
 import { getUmaDisplayInfo } from '@/modules/runners/utils';
 import { MAX_RUNNERS } from '@/store/runners.store';
 import { createSkillSorterByGroup } from './shared';
-import { createCompareSettings, toCreateRunner, toSundayRaceParameters } from './shared-pure';
+import {
+  DEFAULT_DUELING_RATES,
+  createCompareSettings,
+  toCreateRunner,
+  toSundayRaceParameters
+} from './shared-pure';
 import type { ComparePlan } from './wasm-compare';
 
+type ComparePlanMode = ComparePlan['mode'];
+
 export type BuildComparePlanOptions = {
+  mode?: ComparePlanMode;
   /**
-   * Target field size (total gates). Real umas fill first; remaining gates
-   * are padded with generated 600-stat mobs.
+   * Target field size (total gates, contested mode only). Real umas fill first;
+   * remaining gates are padded with generated 600-stat mobs.
    */
   fieldSize?: number;
   /** Extra field runners beyond the compared pair (context / opponents). */
@@ -56,6 +67,7 @@ export function buildComparePlan(
   } = params;
 
   const baseSeed = options.seed ?? 0;
+  const mode = buildOptions.mode ?? 'contested';
   const fieldSize = buildOptions.fieldSize ?? 0;
   const contextRunners = buildOptions.contextRunners ?? [];
   const raceParameters = toSundayRaceParameters(racedef);
@@ -80,10 +92,58 @@ export function buildComparePlan(
     scenarioOverrides?.uma2
   );
 
+  const settingsA = createCompareSettings({
+    healthSystem: true,
+    spotStruggle: true,
+    sectionModifier: options.allowSectionModifierUma1,
+    rushed: options.allowRushedUma1,
+    downhill: options.allowDownhillUma1,
+    conservePower: options.allowConservePowerUma1 ?? false,
+    witChecks: options.skillCheckChanceUma1,
+    staminaDrainOverrides: options.staminaDrainOverrides
+  });
+  const settingsB = createCompareSettings({
+    healthSystem: true,
+    spotStruggle: true,
+    sectionModifier: options.allowSectionModifierUma2,
+    rushed: options.allowRushedUma2,
+    downhill: options.allowDownhillUma2,
+    conservePower: options.allowConservePowerUma2 ?? false,
+    witChecks: options.skillCheckChanceUma2,
+    staminaDrainOverrides: options.staminaDrainOverrides
+  });
+
+  if (mode === 'vacuum') {
+    if (contextRunners.length > 0) {
+      throw new Error('Vacuum compare is duo-only and cannot include context runners');
+    }
+
+    const wasmParamsA = compareParamsToWasm({
+      course,
+      parameters: raceParameters,
+      settings: settingsA,
+      duelingRates: DEFAULT_DUELING_RATES,
+      runner: runnerA,
+      name: resolveRunnerName(runnerA.outfitId, 0),
+      nsamples,
+      masterSeed: baseSeed
+    });
+    const wasmParamsB = compareParamsToWasm({
+      course,
+      parameters: raceParameters,
+      settings: settingsB,
+      duelingRates: DEFAULT_DUELING_RATES,
+      runner: runnerB,
+      name: resolveRunnerName(runnerB.outfitId, 1),
+      nsamples,
+      masterSeed: baseSeed
+    });
+
+    return { mode: 'vacuum', wasmParamsA, wasmParamsB, nsamples, baseSeed };
+  }
+
   // Contested compare runs the live race engine: dueling and position keep
-  // must be ON (matching `run_race_sim` / engine defaults). The
-  // `createCompareSettings` base defaults them off for the planner/basin
-  // vacuum paths.
+  // must be ON (matching `run_race_sim` / engine defaults).
   const settingsContested = createCompareSettings({
     healthSystem: true,
     spotStruggle: true,
@@ -114,7 +174,9 @@ export function buildComparePlan(
       names: [
         resolveRunnerName(runnerA.outfitId, 0),
         resolveRunnerName(runnerB.outfitId, 1),
-        ...contextCreateRunners.map((runner, index) => resolveRunnerName(runner.outfitId, index + 2))
+        ...contextCreateRunners.map((runner, index) =>
+          resolveRunnerName(runner.outfitId, index + 2)
+        )
       ],
       fillTo: computeFillTo(runnerCount, fieldSize),
       nsamples,

--- a/src/modules/simulation/simulators/wasm-compare.test.ts
+++ b/src/modules/simulation/simulators/wasm-compare.test.ts
@@ -2,10 +2,11 @@ import { describe, expect, it, vi } from 'vitest';
 import type { CollectedRunnerRoundData } from '@/lib/uma-domain/race/race-observer';
 import type { CourseData } from '@/lib/uma-domain/course/definitions';
 import type { RaceParameters } from '@/lib/uma-domain/race/types';
-import { createRunnerState } from '@/modules/runners/components/runner-card/types';
+import { createRunnerState, runawaySkillId } from '@/modules/runners/components/runner-card/types';
 import type { CompareParams } from '@/modules/simulation/types';
 import type {
   WasmCompareData,
+  WasmCompareParams,
   WasmCompareRoundData,
   WasmContestedCompareParams
 } from '@/lib/uma-sim-wasm/types';
@@ -16,12 +17,14 @@ import {
   splitContestedCompareRounds,
   type ComparePlan
 } from './wasm-compare';
-import { runContestedCompare } from '@/lib/uma-sim-wasm/loader';
+import { runCompare, runContestedCompare } from '@/lib/uma-sim-wasm/loader';
 
 vi.mock('@/lib/uma-sim-wasm/loader', () => ({
+  runCompare: vi.fn(),
   runContestedCompare: vi.fn()
 }));
 
+const mockedRunCompare = vi.mocked(runCompare);
 const mockedRunContestedCompare = vi.mocked(runContestedCompare);
 
 const course: CourseData = {
@@ -80,7 +83,10 @@ function compareParams(overrides: Partial<CompareParams> = {}): CompareParams {
   };
 }
 
-function wasmRunner(runnerId: number, overrides: Partial<WasmCompareRoundData> = {}): WasmCompareRoundData {
+function wasmRunner(
+  runnerId: number,
+  overrides: Partial<WasmCompareRoundData> = {}
+): WasmCompareRoundData {
   return {
     runnerId,
     time: [0, 1],
@@ -145,6 +151,33 @@ function wasmData(rounds: Array<WasmCompareRoundData[]>): WasmCompareData {
 }
 
 describe('buildComparePlan', () => {
+  it('builds the vacuum plan shape when selected', () => {
+    const plan = buildComparePlan(compareParams(), { mode: 'vacuum' });
+
+    expect(plan.mode).toBe('vacuum');
+    if (plan.mode !== 'vacuum') throw new Error('expected vacuum plan');
+    expect(plan.wasmParamsA.masterSeed).toBe(42);
+    expect(plan.wasmParamsB.masterSeed).toBe(42);
+    expect(plan.nsamples).toBe(8);
+  });
+
+  it('keeps injected debuffs in vacuum runner params', () => {
+    const plan = buildComparePlan(
+      compareParams({
+        injectedDebuffs: {
+          uma1: [{ id: 'debuff-1', skillId: runawaySkillId, position: 100 }],
+          uma2: []
+        }
+      }),
+      { mode: 'vacuum' }
+    );
+
+    if (plan.mode !== 'vacuum') throw new Error('expected vacuum plan');
+    expect(plan.wasmParamsA.runners[0]?.injectedDebuffs).toEqual([
+      expect.objectContaining({ position: 100 })
+    ]);
+  });
+
   it('builds the contested plan shape with both runners in one envelope', () => {
     const plan = buildComparePlan(compareParams(), { fieldSize: 9 });
 
@@ -169,6 +202,15 @@ describe('buildComparePlan', () => {
     // 2 compared + 3 context runners, A first / B second (insertion order)
     expect(plan.wasmParamsContested.runners).toHaveLength(5);
     expect(plan.wasmParamsContested.fillTo).toBeUndefined();
+  });
+
+  it('rejects vacuum plans with context runners', () => {
+    expect(() =>
+      buildComparePlan(compareParams(), {
+        mode: 'vacuum',
+        contextRunners: [createRunnerState()]
+      })
+    ).toThrow('Vacuum compare is duo-only and cannot include context runners');
   });
 });
 
@@ -214,7 +256,9 @@ describe('runComparisonRoundsFromPlan', () => {
 
     const plan: ComparePlan = {
       mode: 'contested',
-      wasmParamsContested: { runners: [{ name: 'A' }, { name: 'B' }] } as WasmContestedCompareParams,
+      wasmParamsContested: {
+        runners: [{ name: 'A' }, { name: 'B' }]
+      } as WasmContestedCompareParams,
       nsamples: 4,
       baseSeed: 100
     };
@@ -226,6 +270,59 @@ describe('runComparisonRoundsFromPlan', () => {
     );
     expect(rounds.roundsA).toHaveLength(1);
     expect(rounds.roundsB).toHaveLength(1);
+  });
+
+  it('splits vacuum batches by each batch primary runner', async () => {
+    mockedRunCompare
+      .mockResolvedValueOnce(wasmData([[wasmRunner(0, { hp: [1000, 900] })]]))
+      .mockResolvedValueOnce(wasmData([[wasmRunner(7, { hp: [1000, 800] })]]));
+
+    const plan: ComparePlan = {
+      mode: 'vacuum',
+      wasmParamsA: {} as WasmCompareParams,
+      wasmParamsB: {} as WasmCompareParams,
+      nsamples: 1,
+      baseSeed: 100
+    };
+
+    const rounds = await runComparisonRoundsFromPlan(plan, 1, 2);
+
+    expect(rounds.roundsA[0]?.runnerId).toBe(0);
+    expect(rounds.roundsB[0]?.runnerId).toBe(7);
+    expect(mockedRunCompare).toHaveBeenCalledTimes(2);
+    expect(mockedRunCompare).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ masterSeed: 102, nsamples: 1 })
+    );
+    expect(mockedRunCompare).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ masterSeed: 102, nsamples: 1 })
+    );
+  });
+
+  it('keeps vacuum chunk seed inputs deterministic across split chunks', async () => {
+    mockedRunCompare.mockClear();
+    mockedRunCompare.mockResolvedValue(wasmData([[wasmRunner(0)], [wasmRunner(0)]]));
+
+    const plan: ComparePlan = {
+      mode: 'vacuum',
+      wasmParamsA: {} as WasmCompareParams,
+      wasmParamsB: {} as WasmCompareParams,
+      nsamples: 4,
+      baseSeed: 10
+    };
+
+    await runComparisonRoundsFromPlan(plan, 2, 0);
+    await runComparisonRoundsFromPlan(plan, 2, 2);
+
+    expect(
+      mockedRunCompare.mock.calls.map(([params]) => [params.masterSeed, params.nsamples])
+    ).toEqual([
+      [10, 2],
+      [10, 2],
+      [12, 2],
+      [12, 2]
+    ]);
   });
 });
 

--- a/src/modules/simulation/simulators/wasm-compare.ts
+++ b/src/modules/simulation/simulators/wasm-compare.ts
@@ -13,12 +13,13 @@ import type {
 import type { CollectedRunnerRoundData } from '@/lib/uma-domain/race/race-observer';
 import type {
   WasmCompareData,
+  WasmCompareParams,
   WasmCompareRoundData,
   WasmContestedCompareParams
 } from '@/lib/uma-sim-wasm/types';
 import { initializeSimulationRun } from '@/modules/simulation/compare.types';
 import { wasmCompareRoundDataToCollected } from '@/lib/uma-sim-wasm/adapter-results';
-import { runContestedCompare } from '@/lib/uma-sim-wasm/loader';
+import { runCompare, runContestedCompare } from '@/lib/uma-sim-wasm/loader';
 import { computePositionDiff } from './shared-pure';
 
 type CompareStatsAccumulator = {
@@ -278,6 +279,17 @@ function reduceCompareRounds(
   };
 }
 
+/** Extract the primary-runner round data from a WASM compare-round list. */
+function primaryRounds(rounds: WasmCompareData['rounds']): Array<CollectedRunnerRoundData> {
+  return rounds.map((round) => {
+    const primary = round.runners[0];
+    if (!primary) {
+      throw new Error('Missing primary runner in WASM compare round');
+    }
+    return wasmCompareRoundDataToCollected(primary);
+  });
+}
+
 function findComparedRunner(
   runners: Array<WasmCompareRoundData>,
   runnerId: number,
@@ -342,6 +354,14 @@ export type CompareRounds = {
  * round 0; chunk `seedOffset` maps global round `seedOffset + j` to master seed
  * `baseSeed + seedOffset + j`, keeping chunked runs bit-for-bit identical.
  */
+type VacuumComparePlan = {
+  mode: 'vacuum';
+  wasmParamsA: WasmCompareParams;
+  wasmParamsB: WasmCompareParams;
+  nsamples: number;
+  baseSeed: number;
+};
+
 type ContestedComparePlan = {
   mode: 'contested';
   wasmParamsContested: WasmContestedCompareParams;
@@ -349,10 +369,10 @@ type ContestedComparePlan = {
   baseSeed: number;
 };
 
-export type ComparePlan = ContestedComparePlan;
+export type ComparePlan = ContestedComparePlan | VacuumComparePlan;
 
 /**
- * Run a WASM contested batch for a prebuilt {@link ComparePlan} and return the
+ * Run the WASM batch or batches for a prebuilt {@link ComparePlan} and return
  * raw per-round A/B telemetry (no reduction). Worker-safe: it only overrides
  * `masterSeed` + `nsamples` on the already-resolved params.
  */
@@ -363,16 +383,26 @@ export async function runComparisonRoundsFromPlan(
 ): Promise<CompareRounds> {
   const masterSeed = plan.baseSeed + seedOffset;
 
-  if (plan.wasmParamsContested.runners.length < 2) {
-    throw new Error('Contested compare plan requires at least two compared runners');
+  if (plan.mode === 'contested') {
+    if (plan.wasmParamsContested.runners.length < 2) {
+      throw new Error('Contested compare plan requires at least two compared runners');
+    }
+
+    const data = await runContestedCompare({
+      ...plan.wasmParamsContested,
+      masterSeed,
+      nsamples: chunkSamples
+    });
+    const rounds = splitContestedCompareRounds(data);
+    assertAlignedRounds(rounds, chunkSamples);
+    return rounds;
   }
 
-  const data = await runContestedCompare({
-    ...plan.wasmParamsContested,
-    masterSeed,
-    nsamples: chunkSamples
-  });
-  const rounds = splitContestedCompareRounds(data);
+  const [dataA, dataB] = await Promise.all([
+    runCompare({ ...plan.wasmParamsA, masterSeed, nsamples: chunkSamples }),
+    runCompare({ ...plan.wasmParamsB, masterSeed, nsamples: chunkSamples })
+  ]);
+  const rounds = { roundsA: primaryRounds(dataA.rounds), roundsB: primaryRounds(dataB.rounds) };
   assertAlignedRounds(rounds, chunkSamples);
   return rounds;
 }

--- a/src/modules/simulation/stores/compare.store.test.ts
+++ b/src/modules/simulation/stores/compare.store.test.ts
@@ -1,7 +1,14 @@
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { createRunnerState } from '@/modules/runners/components/runner-card/types';
+import { useRunnersStore } from '@/store/runners.store';
 import {
+  canUseVacuum,
   clampFieldSize,
+  forceContestedForField,
   migrateComparePersisted,
+  setCompareMode,
+  useRaceStore,
+  DEFAULT_COMPARE_MODE,
   DEFAULT_FIELD_SIZE,
   MIN_FIELD_SIZE
 } from './compare.store';
@@ -13,7 +20,7 @@ describe('migrateComparePersisted', () => {
       1
     );
     expect(migrated.fieldSize).toBe(DEFAULT_FIELD_SIZE);
-    expect(migrated).not.toHaveProperty('compareMode');
+    expect(migrated.compareMode).toBe(DEFAULT_COMPARE_MODE);
   });
 
   it('maps v1 fieldComposition "duo" to the minimum field size (no padding)', () => {
@@ -24,10 +31,10 @@ describe('migrateComparePersisted', () => {
     expect(migrated.fieldSize).toBe(MIN_FIELD_SIZE);
   });
 
-  it('defaults to the default field size when fieldComposition is absent (v1)', () => {
+  it('defaults v1 vacuum state to contested', () => {
     const migrated = migrateComparePersisted({ compareMode: 'vacuum' }, 1);
     expect(migrated.fieldSize).toBe(DEFAULT_FIELD_SIZE);
-    expect(migrated).not.toHaveProperty('compareMode');
+    expect(migrated.compareMode).toBe(DEFAULT_COMPARE_MODE);
   });
 
   it('maps v2 fillWithMobs booleans to field sizes', () => {
@@ -47,6 +54,22 @@ describe('migrateComparePersisted', () => {
     expect(migrateComparePersisted({ fieldSize: 99 }, 3).fieldSize).toBe(12);
     expect(migrateComparePersisted({}, 3).fieldSize).toBe(DEFAULT_FIELD_SIZE);
   });
+
+  it('defaults a v4 blob to contested even when it contains vacuum', () => {
+    expect(migrateComparePersisted({ compareMode: 'vacuum' }, 4).compareMode).toBe(
+      DEFAULT_COMPARE_MODE
+    );
+  });
+
+  it('preserves vacuum from a v5 blob', () => {
+    expect(migrateComparePersisted({ compareMode: 'vacuum' }, 5).compareMode).toBe('vacuum');
+  });
+
+  it('clamps an invalid v5 compare mode to contested', () => {
+    expect(migrateComparePersisted({ compareMode: 'invalid' }, 5).compareMode).toBe(
+      DEFAULT_COMPARE_MODE
+    );
+  });
 });
 
 describe('clampFieldSize', () => {
@@ -55,5 +78,43 @@ describe('clampFieldSize', () => {
     expect(clampFieldSize(13)).toBe(12);
     expect(clampFieldSize(9.6)).toBe(10);
     expect(clampFieldSize(Number.NaN)).toBe(DEFAULT_FIELD_SIZE);
+  });
+});
+
+describe('compare mode guards', () => {
+  const seedRunners = (count: number) => {
+    const runners = Array.from({ length: count }, (_, index) => ({
+      ...createRunnerState(),
+      fieldId: `runner-${index}`
+    }));
+    useRunnersStore.setState({
+      runners,
+      compareA: runners[0].fieldId,
+      compareB: runners[1].fieldId,
+      editingId: runners[0].fieldId
+    });
+  };
+
+  beforeEach(() => {
+    seedRunners(MIN_FIELD_SIZE);
+    useRaceStore.setState({ compareMode: DEFAULT_COMPARE_MODE });
+  });
+
+  it('allows vacuum only for a duo field', () => {
+    expect(canUseVacuum(2)).toBe(true);
+    expect(canUseVacuum(3)).toBe(false);
+    expect(canUseVacuum(12)).toBe(false);
+  });
+
+  it('refuses vacuum when the runner field exceeds a duo', () => {
+    seedRunners(3);
+    setCompareMode('vacuum');
+    expect(useRaceStore.getState().compareMode).toBe(DEFAULT_COMPARE_MODE);
+  });
+
+  it('forces contested mode when the field grows past a duo', () => {
+    setCompareMode('vacuum');
+    forceContestedForField();
+    expect(useRaceStore.getState().compareMode).toBe(DEFAULT_COMPARE_MODE);
   });
 });

--- a/src/modules/simulation/stores/compare.store.test.ts
+++ b/src/modules/simulation/stores/compare.store.test.ts
@@ -6,6 +6,7 @@ import {
   clampFieldSize,
   forceContestedForField,
   migrateComparePersisted,
+  reconcileCompareModeWithField,
   setCompareMode,
   useRaceStore,
   DEFAULT_COMPARE_MODE,
@@ -116,5 +117,18 @@ describe('compare mode guards', () => {
     setCompareMode('vacuum');
     forceContestedForField();
     expect(useRaceStore.getState().compareMode).toBe(DEFAULT_COMPARE_MODE);
+  });
+
+  it('reconciles a persisted vacuum mode against a >2 field at startup', () => {
+    seedRunners(3);
+    useRaceStore.setState({ compareMode: 'vacuum' });
+    reconcileCompareModeWithField();
+    expect(useRaceStore.getState().compareMode).toBe(DEFAULT_COMPARE_MODE);
+  });
+
+  it('leaves a persisted vacuum mode alone for a duo field', () => {
+    setCompareMode('vacuum');
+    reconcileCompareModeWithField();
+    expect(useRaceStore.getState().compareMode).toBe('vacuum');
   });
 });

--- a/src/modules/simulation/stores/compare.store.test.ts
+++ b/src/modules/simulation/stores/compare.store.test.ts
@@ -119,6 +119,13 @@ describe('compare mode guards', () => {
     expect(useRaceStore.getState().compareMode).toBe(DEFAULT_COMPARE_MODE);
   });
 
+  it('forces contested via subscription when the runners store grows past a duo', () => {
+    setCompareMode('vacuum');
+    expect(useRaceStore.getState().compareMode).toBe('vacuum');
+    seedRunners(3);
+    expect(useRaceStore.getState().compareMode).toBe(DEFAULT_COMPARE_MODE);
+  });
+
   it('reconciles a persisted vacuum mode against a >2 field at startup', () => {
     seedRunners(3);
     useRaceStore.setState({ compareMode: 'vacuum' });

--- a/src/modules/simulation/stores/compare.store.ts
+++ b/src/modules/simulation/stores/compare.store.ts
@@ -156,6 +156,18 @@ export const forceContestedForField = () => {
   useRaceStore.setState({ compareMode: DEFAULT_COMPARE_MODE });
 };
 
+/** Startup reconciliation: vacuum is duo-only, but `compareMode` and the runner list persist in separate stores. An interrupted write (or storage tampering) can leave a persisted vacuum mode alongside a >2 field; fall back to contested. Runs once at module load, after both stores rehydrate synchronously (the runners store rehydrates first because this module imports it). Exported for unit tests. */
+export const reconcileCompareModeWithField = () => {
+  if (
+    useRaceStore.getState().compareMode === 'vacuum' &&
+    !canUseVacuum(useRunnersStore.getState().runners.length)
+  ) {
+    forceContestedForField();
+  }
+};
+
+reconcileCompareModeWithField();
+
 export const setFieldSize = (fieldSize: number) => {
   useRaceStore.setState({ fieldSize: clampFieldSize(fieldSize) });
 };

--- a/src/modules/simulation/stores/compare.store.ts
+++ b/src/modules/simulation/stores/compare.store.ts
@@ -166,7 +166,8 @@ export const reconcileCompareModeWithField = () => {
   }
 };
 
-reconcileCompareModeWithField();
+// Deferred to a microtask: this store and runners.store import each other (runners.store calls forceContestedForField), so running at module scope can dereference `useRunnersStore` while runners.store is still mid-initialization (TDZ ReferenceError when a vacuum mode was persisted). After the module graph settles both stores exist and have rehydrated.
+queueMicrotask(reconcileCompareModeWithField);
 
 export const setFieldSize = (fieldSize: number) => {
   useRaceStore.setState({ fieldSize: clampFieldSize(fieldSize) });

--- a/src/modules/simulation/stores/compare.store.ts
+++ b/src/modules/simulation/stores/compare.store.ts
@@ -166,8 +166,15 @@ export const reconcileCompareModeWithField = () => {
   }
 };
 
-// Deferred to a microtask: this store and runners.store import each other (runners.store calls forceContestedForField), so running at module scope can dereference `useRunnersStore` while runners.store is still mid-initialization (TDZ ReferenceError when a vacuum mode was persisted). After the module graph settles both stores exist and have rehydrated.
-queueMicrotask(reconcileCompareModeWithField);
+// Safe as a plain module-scope call: the store dependency is one-directional (this module imports runners.store; runners.store must never import back — that cycle once made this exact line a TDZ crash in the production bundle), so runners.store is fully initialized and rehydrated before this body runs.
+reconcileCompareModeWithField();
+
+// Field-growth enforcement: vacuum is duo-only, and runners.store cannot call forceContestedForField without recreating the module cycle above. React to any field change instead — this also covers every future growth path (addRunner, imports, whatever comes next) without per-callsite calls.
+useRunnersStore.subscribe((state, prevState) => {
+  if (state.runners.length !== prevState.runners.length) {
+    reconcileCompareModeWithField();
+  }
+});
 
 export const setFieldSize = (fieldSize: number) => {
   useRaceStore.setState({ fieldSize: clampFieldSize(fieldSize) });

--- a/src/modules/simulation/stores/compare.store.ts
+++ b/src/modules/simulation/stores/compare.store.ts
@@ -17,6 +17,10 @@ import { MIN_RUNNERS, useRunnersStore } from '@/store/runners.store';
 
 const COMPARE_DEBUFFS_STORE_NAME = 'umalator-compare-debuffs';
 
+export type CompareMode = 'contested' | 'vacuum';
+
+export const DEFAULT_COMPARE_MODE: CompareMode = 'contested';
+
 // The user-facing "field size" (total gates). Real umas fill first; remaining
 // gates are padded with generated 600-stat mobs. Default 9: the
 // field-composition experiment (docs/dev-process/spike-contested-compare.md)
@@ -32,8 +36,16 @@ export const clampFieldSize = (value: number): number => {
   return Math.min(MAX_FIELD_SIZE, Math.max(MIN_FIELD_SIZE, Math.round(value)));
 };
 
+const isCompareMode = (value: unknown): value is CompareMode => {
+  return value === 'contested' || value === 'vacuum';
+};
+
+/** Vacuum mode compares two isolated runners; it is only valid for a duo field. */
+export const canUseVacuum = (fieldSize: number): boolean => fieldSize <= MIN_RUNNERS;
+
 type PersistedRaceStore = {
   injectedDebuffs?: InjectedDebuffsMap;
+  compareMode?: CompareMode;
   fieldSize?: number;
 };
 
@@ -53,6 +65,7 @@ type IRaceStore = {
   isSimulationRunning: boolean;
   simulationProgress: { current: number; total: number } | null;
   injectedDebuffs: InjectedDebuffsMap;
+  compareMode: CompareMode;
   fieldSize: number;
 };
 
@@ -74,17 +87,18 @@ export const useRaceStore = create<IRaceStore>()(
       isSimulationRunning: false,
       simulationProgress: null,
       injectedDebuffs: { uma1: [], uma2: [] },
+      compareMode: DEFAULT_COMPARE_MODE,
       fieldSize: DEFAULT_FIELD_SIZE
     }),
     {
       name: COMPARE_DEBUFFS_STORE_NAME,
       storage: createJSONStorage(() => localStorage),
-      // v4 drops `compareMode`: compare is contested-only (persisted 'vacuum'
-      // silently migrates away).
-      version: 4,
+      // v4 dropped `compareMode`; v5 reintroduces it with contested as the default.
+      version: 5,
       migrate: (persistedState, version) => migrateComparePersisted(persistedState, version),
       partialize: (state) => ({
         injectedDebuffs: state.injectedDebuffs,
+        compareMode: state.compareMode,
         fieldSize: state.fieldSize
       })
     }
@@ -101,10 +115,7 @@ export const migrateComparePersisted = (
     fillWithMobs?: boolean;
   };
 
-  // v1 stored `fieldComposition: 'duo' | 'mobs'`; v2 stored
-  // `fillWithMobs: boolean`; v3+ stores the explicit `fieldSize` (total
-  // gates). v4 drops `compareMode` entirely (contested-only compare); any
-  // persisted 'vacuum' from v3 is silently discarded.
+  // v1 stored `fieldComposition: 'duo' | 'mobs'`; v2 stored `fillWithMobs: boolean`; v3+ stores the explicit `fieldSize` (total gates). v4 dropped `compareMode`; v5 reintroduces it with contested as the default, so v4 and older persisted modes are ignored.
   let fieldSize: number;
   if (version >= 3) {
     fieldSize = clampFieldSize(state.fieldSize ?? DEFAULT_FIELD_SIZE);
@@ -119,12 +130,30 @@ export const migrateComparePersisted = (
 
   return {
     injectedDebuffs: state.injectedDebuffs ?? { uma1: [], uma2: [] },
+    compareMode:
+      version <= 4
+        ? DEFAULT_COMPARE_MODE
+        : isCompareMode(state.compareMode)
+          ? state.compareMode
+          : DEFAULT_COMPARE_MODE,
     fieldSize
   } satisfies PersistedRaceStore;
 };
 
 export const setCompareSeed = (seed: number | null) => {
   useRaceStore.setState({ seed });
+};
+
+export const setCompareMode = (compareMode: CompareMode) => {
+  if (compareMode === 'vacuum' && !canUseVacuum(useRunnersStore.getState().runners.length)) {
+    return;
+  }
+
+  useRaceStore.setState({ compareMode });
+};
+
+export const forceContestedForField = () => {
+  useRaceStore.setState({ compareMode: DEFAULT_COMPARE_MODE });
 };
 
 export const setFieldSize = (fieldSize: number) => {
@@ -267,6 +296,7 @@ export const useDebuffs = (): InjectedDebuffsMap => {
 export const useCompareSettings = () => {
   return useRaceStore(
     useShallow((state) => ({
+      compareMode: state.compareMode,
       fieldSize: state.fieldSize
     }))
   );

--- a/src/store/runners.store.ts
+++ b/src/store/runners.store.ts
@@ -8,6 +8,7 @@ import type { IRunnerState } from '@/modules/runners/components/runner-card/type
 import { createRunnerState, runawaySkillId } from '@/modules/runners/components/runner-card/types';
 import { getGeneVersionSkillId, getUniqueSkillForByUmaId } from '@/modules/skills/utils';
 import { skillsService } from '@/modules/data/services/SkillService';
+import { forceContestedForField } from '@/modules/simulation/stores/compare.store';
 
 export const MIN_RUNNERS = 2;
 export const MAX_RUNNERS = 12;
@@ -304,6 +305,9 @@ export const addRunner = (): string | null => {
 
   const runner: FieldRunner = { ...createRunnerState(), fieldId: createFieldId() };
   useRunnersStore.setState((prev) => ({ runners: [...prev.runners, runner] }));
+
+  // Growing the field past a duo forces contested compare (vacuum is duo-only).
+  forceContestedForField();
 
   return runner.fieldId;
 };

--- a/src/store/runners.store.ts
+++ b/src/store/runners.store.ts
@@ -8,7 +8,6 @@ import type { IRunnerState } from '@/modules/runners/components/runner-card/type
 import { createRunnerState, runawaySkillId } from '@/modules/runners/components/runner-card/types';
 import { getGeneVersionSkillId, getUniqueSkillForByUmaId } from '@/modules/skills/utils';
 import { skillsService } from '@/modules/data/services/SkillService';
-import { forceContestedForField } from '@/modules/simulation/stores/compare.store';
 
 export const MIN_RUNNERS = 2;
 export const MAX_RUNNERS = 12;
@@ -304,10 +303,8 @@ export const addRunner = (): string | null => {
   }
 
   const runner: FieldRunner = { ...createRunnerState(), fieldId: createFieldId() };
+  // Growing the field past a duo forces contested compare (vacuum is duo-only): the compare store subscribes to this store and reacts to the length change. Do not import compare.store from here — that back-edge creates a module cycle (see compare.store's field-growth subscription).
   useRunnersStore.setState((prev) => ({ runners: [...prev.runners, runner] }));
-
-  // Growing the field past a duo forces contested compare (vacuum is duo-only).
-  forceContestedForField();
 
   return runner.fieldId;
 };


### PR DESCRIPTION
Reinstates the vacuum (isolated paired-delta) compare simulation — removed in #63 when compare went contested-only — as an **opt-in toggle** for duo fields. Users asked for it back; contested same-race compare stays the default and nothing changes unless the toggle is flipped.

## Mode selection

```mermaid
flowchart TD
  S["compare.store<br/>compareMode (persist v5, default contested)"] --> B{"buildComparePlan<br/>mode?"}
  B -->|"contested (default)"| C["run_contested_compare<br/>one shared race, 2–12 field<br/>dueling + positionKeep ON"]
  B -->|"vacuum (duo only)"| V["runCompare ×2<br/>isolated races, paired by seed<br/>dueling + positionKeep OFF"]
  C --> R["reduceCompareRounds → bashin delta"]
  V --> R
  G["addRunner / field &gt; 2"] -->|forceContestedForField| S
```

## What's here
- **stores/compare.store.ts** — `compareMode` state (persist v4→v5 migration defaults everyone to contested), `canUseVacuum` (duo-only), `setCompareMode` guard, and a startup reconciliation that clamps a persisted vacuum mode against an oversized runner field.
- **simulators/wasm-compare{,-plan}.ts** — `ComparePlan` is a union again: the vacuum branch builds per-runner params and runs the existing WASM `runCompare` twice with paired seeds (no Rust changes; the engine never left — planner/basin still use it).
- **field-manager-content.tsx** — "Same race / Vacuum" radiogroup, rendered only for duo fields; field-size controls lock while vacuum is active.
- **share/** — snapshots round-trip `compareMode` (vacuum imports force fieldSize 2); legacy pre-mode shares still coerce to contested with the warning toast.
- **.hiker tent + ADR-0007** — `compare_flow_contested_only` law replaced with `vacuum_run_is_duo`; ADR amended (it always said vacuum compare should survive as the isolated paired-delta use case).

## Gates
typecheck ✅ · 389 tests ✅ (+14) · lint 0 · knip 0 · intent OK (6 laws).

> Behavior note: vacuum results intentionally differ from contested — dueling, spot-struggle, and position-keep stats reduce to zero-frequency there. A parity review against the pre-removal implementation (`7d6d1db7^`) found no drift beyond the intentional default flip.

Plan: `.taskman/plans/vacuum-compare-toggle` · Removal this restores: #63 / ADR-0007.
