### PR TITLE
feat(skills): show special scaling in tooltips

### DIFF
--- a/docs/mechanics/README.md
+++ b/docs/mechanics/README.md
@@ -751,7 +751,9 @@ The effectiveness of aoharu skills scales with your team’s total [base stats](
 | 2600 \<= Total \< 3600 | 1.1x          |
 | 3600 \<= Total         | 1.2x          |
 
-Outside the Aoharu scenario (Team Trials, Champions Meetings), these skills apply their base value with no team-stats bonus (1.0x), as verified by in-game observation on Global with **Ignited Spirit** (210031/210032).
+This scaling also applies outside the Aoharu scenario: in Team Trials and Champions Meetings the multiplier is computed at race time from the racing team's combined base stat matching the skill (mood-adjusted; green skills excluded), as verified by in-game observation on Global (2026-07) and corroborated by uma.guide ("Ignited Spirit SPD ... 0.15 at base, 0.18 in Champions Meeting with a full 3600 team") and GameTora's skill tooltips. An earlier note here claimed the base value applies unchanged (1.0x) outside the scenario; that observation was made with a team in the 1800-2599 window, where the 1.0x tier is indistinguishable from "no scaling", and is superseded.
+
+The data extract pre-applies the best tier (1.2x) to these skills' stored modifiers (`patchModifier` in `scripts/data-extract/extract-skills.ts`, inherited from the original umalator), so the simulator always runs the >= 3600-total assumption. A racing team below that threshold receives a smaller effect in-game than the simulator models.
 
 ### Multiply Random (8, 9\) {#multiply-random-(8,-9)}
 

--- a/docs/mechanics/quick-reference.md
+++ b/docs/mechanics/quick-reference.md
@@ -90,7 +90,7 @@ This document is a quick reference for the race mechanics that are available cur
 
 - ✅ `Direct` (1)
 - ❌ `MultiplySkillNum` (2)
-- ❌ `Aoharu` skills (3-7)
+- ✅ `Aoharu` skills (3-7) — team-stat tiers apply in TT/CM; extract pre-applies the best tier (1.2×), so the sim assumes a ≥3600-total team
 - ✅ `MultiplyRandom` (8, 9)
 - ❌ `Climax` skills (10)
 - ❌ `MultiplyMaximumRawStatus` (13)

--- a/packages/uma-sim-primitives/src/skills/value_scaling.rs
+++ b/packages/uma-sim-primitives/src/skills/value_scaling.rs
@@ -16,11 +16,12 @@ pub enum ValueScalingPolicy {
     Direct,
     /// The effect is multiplied by one random 0×/0.02×/0.04× roll.
     MultiplyRandom,
-    /// Aoharu-scenario team-stats scaling (usages 3–7). The multiplier tier is
-    /// driven by the training team's total base stats, a datum that only exists
-    /// inside the Aoharu scenario. Outside the scenario (CM / Team Trials — the
-    /// races this simulator models) the game applies the base value unchanged
-    /// (1.0×), so this policy resolves to the direct modifier. See
+    /// Aoharu team-stats scaling (usages 3–7). The multiplier tier (0.8×–1.2×)
+    /// is computed at race time from the racing team's combined base stat and
+    /// applies in TT/CM as well as in-scenario. The data extract pre-applies
+    /// the best tier (1.2×) to the stored modifier (`patchModifier` in
+    /// extract-skills.ts), so this policy resolves to the direct modifier —
+    /// the ≥3600-total-team assumption is baked into the data. See
     /// docs/mechanics/README.md § "Aoharu Skills (3-7)".
     MultiplyAoharuTeamStats,
     /// Reserved for usage 14, enabled once activated-tag state exists.
@@ -62,8 +63,8 @@ impl ValueScalingPolicy {
     pub fn supports_effect_type(self, effect_type: SkillType) -> bool {
         match self {
             Self::Direct => true,
-            // Resolves as the direct value outside the Aoharu scenario; no
-            // type restriction (Ignited Spirit scales Acceleration).
+            // Resolves as the direct (pre-fudged best-tier) value; no type
+            // restriction (Ignited Spirit scales Acceleration).
             Self::MultiplyAoharuTeamStats => true,
             Self::MultiplyRandom => effect_type == SkillType::Recovery,
             // Usage 14 is a generic count-based value multiplier (Copano Rickey
@@ -161,7 +162,7 @@ pub fn resolve_modifier(
 ) -> Result<f64, ResolveError> {
     match effect.value_scaling {
         ValueScalingPolicy::Direct => Ok(effect.modifier),
-        // 1.0× outside the Aoharu scenario; see the variant doc comment.
+        // Best tier (1.2×) is pre-applied at extraction; see the variant doc comment.
         ValueScalingPolicy::MultiplyAoharuTeamStats => Ok(effect.modifier),
         ValueScalingPolicy::MultiplyRandom => {
             if effect.effect_type != SkillType::Recovery {
@@ -271,9 +272,11 @@ mod tests {
     }
 
     #[test]
-    fn aoharu_team_stats_resolves_to_base_modifier_outside_scenario() {
-        // Ignited Spirit (210031/210032): Acceleration with usage 5. Outside
-        // the Aoharu scenario the game applies no team-stats bonus.
+    fn aoharu_team_stats_resolves_stored_modifier_as_direct() {
+        // Ignited Spirit (210031/210032): Acceleration with usage 5. The tier
+        // scaling applies in TT/CM, but the extract already multiplied the
+        // stored modifier by the best tier (1.2×), so the engine passes it
+        // through unchanged.
         let effect = spec(
             SkillType::Accel,
             0.2,

--- a/scripts/data-extract/extract-skills.ts
+++ b/scripts/data-extract/extract-skills.ts
@@ -219,6 +219,7 @@ function parseCliArgs(argv: Array<string>): ExtractSkillsOptions {
   };
 }
 
+// Scenario skills (Aoharu usages 3–7 and kin) scale at race time with the racing team's combined stats, including in TT/CM. We can't know the team here, so pre-apply the best tier (1.2×) — the sim then treats the value as Direct. See docs/mechanics/README.md § "Aoharu Skills (3-7)".
 function patchModifier(id: number, value: number): number {
   if (SCENARIO_SKILLS.has(id)) {
     return value * 1.2;

--- a/src/lib/uma-domain/skills/simulatability.test.ts
+++ b/src/lib/uma-domain/skills/simulatability.test.ts
@@ -173,9 +173,10 @@ describe('SkillService.isSimulatable', () => {
     }
   });
 
-  it('treats the Aoharu family (usages 3–7) as simulatable at base value', () => {
-    // Fervor / Ignited Spirit lines: team-stats scaling only applies inside
-    // the Aoharu scenario; normal races use the base value (1.0x).
+  it('treats the Aoharu family (usages 3–7) as simulatable at the pre-fudged best tier', () => {
+    // Fervor / Ignited Spirit lines: team-stats scaling applies in TT/CM, but
+    // the extract pre-applies the best tier (1.2x), so the sim runs the stored
+    // value as Direct. See docs/mechanics/README.md § "Aoharu Skills (3-7)".
     const aoharu = [
       '210011',
       '210012',

--- a/src/lib/uma-domain/skills/value-scaling/activated-tag-count.ts
+++ b/src/lib/uma-domain/skills/value-scaling/activated-tag-count.ts
@@ -1,10 +1,18 @@
 import type {
   ScalingEffectLike,
+  ValueScalingDisplayModel,
   ValueScalingDescriptor,
   ValueScalingDisplayContext
 } from './descriptor.types';
 
 const TIER_RULE = 'Activated greens: 0–2 → 0×, 3–4 → 1×, 5 → 2×, 6+ → 3×';
+
+const GREEN_TIERS = [
+  { label: '0–2', multiplier: 0 },
+  { label: '3–4', multiplier: 1 },
+  { label: '5', multiplier: 2 },
+  { label: '6+', multiplier: 3 }
+] as const;
 
 // Mirrors packages/uma-sim-primitives/src/skills/value_scaling.rs activated_tagged_multiplier.
 export function activatedTaggedMultiplier(activatedGreenCount: number): number {
@@ -14,20 +22,55 @@ export function activatedTaggedMultiplier(activatedGreenCount: number): number {
   return 3;
 }
 
-function formatModifier(modifier: number): string {
-  return `${modifier >= 0 ? '+' : ''}${modifier.toFixed(2).replace(/\.0+$/, '')}`;
+function activeTierIndex(activatedGreenCount: number): number {
+  if (activatedGreenCount <= 2) return 0;
+  if (activatedGreenCount <= 4) return 1;
+  if (activatedGreenCount === 5) return 2;
+  return 3;
 }
 
-export function resolveActivatedTagCountDisplay(
-  effect: ScalingEffectLike,
+function buildActivatedTagCountDisplay(
+  effects: ReadonlyArray<ScalingEffectLike>,
   context: ValueScalingDisplayContext
-): string | null {
+): ValueScalingDisplayModel {
   if (context.activatedGreenCount === undefined) {
-    return null;
+    return {
+      usage: 14,
+      header: 'Scales with activated greens',
+      resolution: 'resolved',
+      tiers: GREEN_TIERS,
+      notes: ['The exact bonus is determined after green skills activate during the race.']
+    };
   }
 
-  const multiplier = activatedTaggedMultiplier(context.activatedGreenCount);
-  return `${context.activatedGreenCount} activated greens → ${multiplier}× → ${formatModifier(effect.modifier * multiplier)}`;
+  const { activatedGreenCount } = context;
+  const multiplier = activatedTaggedMultiplier(activatedGreenCount);
+  if (multiplier === 0) {
+    return {
+      usage: 14,
+      header: 'Scales with activated greens',
+      resolution: 'resolved',
+      tiers: GREEN_TIERS,
+      activeTierIndex: activeTierIndex(activatedGreenCount),
+      trailing: `${activatedGreenCount} active → 0×`,
+      notes: ['No bonus below 3 active greens.']
+    };
+  }
+
+  return {
+    usage: 14,
+    header: 'Scales with activated greens',
+    resolution: 'resolved',
+    tiers: GREEN_TIERS,
+    activeTierIndex: activeTierIndex(activatedGreenCount),
+    trailing: `${activatedGreenCount} active → ${multiplier}×`,
+    rows: effects.map((effect) => ({
+      effectType: effect.type,
+      base: effect.modifier,
+      multiplier,
+      result: effect.modifier * multiplier
+    }))
+  };
 }
 
 export const activatedTagCountValueScalingDescriptor: ValueScalingDescriptor = Object.freeze({
@@ -35,5 +78,5 @@ export const activatedTagCountValueScalingDescriptor: ValueScalingDescriptor = O
   name: 'MultiplyActivateSpecificTagSkillCount',
   simulatable: true,
   describe: () => TIER_RULE,
-  resolveDisplay: resolveActivatedTagCountDisplay
+  buildDisplay: buildActivatedTagCountDisplay
 });

--- a/src/lib/uma-domain/skills/value-scaling/aoharu-team-stats.ts
+++ b/src/lib/uma-domain/skills/value-scaling/aoharu-team-stats.ts
@@ -1,16 +1,52 @@
-import type { ValueScalingDescriptor } from './descriptor.types';
+import type {
+  ScalingEffectLike,
+  ValueScalingDescriptor,
+  ValueScalingDisplayModel
+} from './descriptor.types';
+
+const BEST_TIER_MULTIPLIER = 1.2;
+
+const AOHARU_TIERS = [
+  { label: '<1200', multiplier: 0.8 },
+  { label: '1200–1799', multiplier: 0.9 },
+  { label: '1800–2599', multiplier: 1 },
+  { label: '2600–3599', multiplier: 1.1 },
+  { label: '3600+', multiplier: BEST_TIER_MULTIPLIER }
+] as const;
+
+function buildAoharuTeamStatsDisplay(
+  effects: ReadonlyArray<ScalingEffectLike>
+): ValueScalingDisplayModel {
+  return {
+    usage: effects[0]?.valueUsage ?? 3,
+    header: 'Scales with racing-team stats',
+    resolution: 'fixed',
+    tiers: AOHARU_TIERS,
+    activeTierIndex: AOHARU_TIERS.length - 1,
+    trailing: 'best tier pre-applied → 1.2×',
+    rows: effects.map((effect) => ({
+      effectType: effect.type,
+      base: effect.modifier / BEST_TIER_MULTIPLIER,
+      multiplier: BEST_TIER_MULTIPLIER,
+      result: effect.modifier
+    })),
+    notes: ['The extract pre-applies the best tier, so the simulator assumes a 3600+ team total.']
+  };
+}
 
 /**
- * Aoharu-scenario team-stats scaling (usages 3–7). The multiplier tier
- * (0.8x–1.2x) is driven by the training team's total base stats, a datum that
- * only exists inside the Aoharu scenario. Outside the scenario (CM / Team
- * Trials — the races this simulator models) the game applies the base value
- * unchanged (1.0x), so the engine resolves these effects as Direct.
+ * Aoharu team-stats scaling (usages 3–7). The multiplier tier (0.8x–1.2x) is
+ * computed at race time from the racing team's combined base stat matching the
+ * skill, and applies in TT/CM as well as in-scenario. The data extract
+ * pre-applies the best tier (1.2x) to the stored modifier (`patchModifier` in
+ * extract-skills.ts), so the engine resolves these effects as Direct on the
+ * already-scaled value — assuming a >= 3600-total team.
  * See docs/mechanics/README.md § "Aoharu Skills (3-7)".
  */
 export const aoharuTeamStatsValueScalingDescriptor: ValueScalingDescriptor = Object.freeze({
   usage: [3, 4, 5, 6, 7],
   name: 'MultiplyAoharuTeamStats',
   simulatable: true,
-  describe: () => 'Scales with Aoharu team stats in-scenario; base value (1.0×) in normal races'
+  describe: () => 'Scales with racing-team stats (0.8–1.2×); best tier (1.2×) already applied',
+  buildDisplay: buildAoharuTeamStatsDisplay
 });

--- a/src/lib/uma-domain/skills/value-scaling/climax-races-won.ts
+++ b/src/lib/uma-domain/skills/value-scaling/climax-races-won.ts
@@ -1,0 +1,41 @@
+import type {
+  ScalingEffectLike,
+  ValueScalingDescriptor,
+  ValueScalingDisplayModel
+} from './descriptor.types';
+
+const CLIMAX_TIERS = [
+  { label: '<6', multiplier: 0.8 },
+  { label: '6–13', multiplier: 0.9 },
+  { label: '14–17', multiplier: 1 },
+  { label: '18–24', multiplier: 1.1 },
+  { label: '25+', multiplier: 1.2 }
+] as const;
+
+function buildClimaxRacesWonDisplay(
+  effects: ReadonlyArray<ScalingEffectLike>
+): ValueScalingDisplayModel {
+  return {
+    usage: 10,
+    header: 'Scales with training races won',
+    resolution: 'unsupported',
+    tiers: CLIMAX_TIERS,
+    activeTierIndex: CLIMAX_TIERS.length - 1,
+    trailing: 'best tier pre-applied → 1.2×',
+    rows: effects.map((effect) => ({
+      effectType: effect.type,
+      base: effect.modifier / 1.2,
+      multiplier: 1.2,
+      result: effect.modifier
+    })),
+    notes: ['The extract pre-applies the best tier. This scaling is not yet simulated.']
+  };
+}
+
+export const climaxRacesWonValueScalingDescriptor: ValueScalingDescriptor = Object.freeze({
+  usage: [10],
+  name: 'MultiplyClimaxRacesWon',
+  simulatable: false,
+  describe: () => 'Scales with training races won (0.8–1.2×); not yet simulated',
+  buildDisplay: buildClimaxRacesWonDisplay
+});

--- a/src/lib/uma-domain/skills/value-scaling/descriptor.types.ts
+++ b/src/lib/uma-domain/skills/value-scaling/descriptor.types.ts
@@ -8,13 +8,36 @@ export type ValueScalingDisplayContext = {
   activatedGreenCount?: number;
 };
 
+type ValueScalingTier = {
+  label: string;
+  multiplier: number;
+};
+
+export type ValueScalingRow = {
+  effectType: number;
+  base: number;
+  multiplier: number;
+  result: number;
+};
+
+export type ValueScalingDisplayModel = {
+  usage: number;
+  header: string;
+  resolution: 'resolved' | 'fixed' | 'unsupported';
+  tiers?: ReadonlyArray<ValueScalingTier>;
+  activeTierIndex?: number;
+  trailing?: string;
+  rows?: ReadonlyArray<ValueScalingRow>;
+  notes?: ReadonlyArray<string>;
+};
+
 export type ValueScalingDescriptor = {
   usage: ReadonlyArray<number>;
   name: string;
   simulatable: boolean;
   describe: (effect: ScalingEffectLike) => string | null;
-  resolveDisplay?: (
-    effect: ScalingEffectLike,
+  buildDisplay?: (
+    effects: ReadonlyArray<ScalingEffectLike>,
     context: ValueScalingDisplayContext
-  ) => string | null;
+  ) => ValueScalingDisplayModel | null;
 };

--- a/src/lib/uma-domain/skills/value-scaling/registry.test.ts
+++ b/src/lib/uma-domain/skills/value-scaling/registry.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { activatedTaggedMultiplier, resolveActivatedTagCountDisplay } from './activated-tag-count';
-import { describeValueScaling, supportedSimulatableValueUsages } from './registry';
+import { activatedTaggedMultiplier } from './activated-tag-count';
+import {
+  buildValueScalingDisplay,
+  describeValueScaling,
+  supportedSimulatableValueUsages
+} from './registry';
 
 describe('value-scaling descriptor registry', () => {
   it('keeps Direct effects on the numeric display fallback', () => {
@@ -16,7 +20,7 @@ describe('value-scaling descriptor registry', () => {
 
   it('describes Aoharu team-stats scaling (Ignited Spirit, usage 5)', () => {
     expect(describeValueScaling({ type: 31, modifier: 0.2, valueUsage: 5 })).toBe(
-      'Scales with Aoharu team stats in-scenario; base value (1.0×) in normal races'
+      'Scales with racing-team stats (0.8–1.2×); best tier (1.2×) already applied'
     );
   });
 
@@ -47,9 +51,81 @@ describe('value-scaling descriptor registry', () => {
     expect(activatedTaggedMultiplier(greens)).toBe(multiplier);
   });
 
-  it('resolves a known green count into the scaled display value', () => {
+  it.each([
+    [0, 0, 0],
+    [2, 0, 0],
+    [3, 1, 1],
+    [5, 2, 2],
+    [6, 3, 3]
+  ])(
+    'builds the usage-14 display at %i active greens',
+    (activatedGreenCount, multiplier, activeTierIndex) => {
+      const [model] = buildValueScalingDisplay(
+        [
+          { type: 27, modifier: 0.05, valueUsage: 14 },
+          { type: 31, modifier: 0.05, valueUsage: 14 }
+        ],
+        { activatedGreenCount }
+      );
+
+      expect(model).toMatchObject({
+        usage: 14,
+        resolution: 'resolved',
+        activeTierIndex,
+        trailing: `${activatedGreenCount} active → ${multiplier}×`
+      });
+      expect(model.rows).toEqual(
+        multiplier === 0
+          ? undefined
+          : [
+              { effectType: 27, base: 0.05, multiplier, result: 0.05 * multiplier },
+              { effectType: 31, base: 0.05, multiplier, result: 0.05 * multiplier }
+            ]
+      );
+    }
+  );
+
+  it('builds the Aoharu best-tier display from pre-fudged values', () => {
+    const [model] = buildValueScalingDisplay([{ type: 31, modifier: 0.24, valueUsage: 5 }], {});
+
+    expect(model).toMatchObject({
+      usage: 5,
+      header: 'Scales with racing-team stats',
+      resolution: 'fixed',
+      activeTierIndex: 4,
+      trailing: 'best tier pre-applied → 1.2×'
+    });
+    expect(model.rows?.[0]).toMatchObject({
+      effectType: 31,
+      multiplier: 1.2,
+      result: 0.24
+    });
+    expect(model.rows?.[0].base).toBeCloseTo(0.2);
+  });
+
+  it('builds an unsupported Climax display without marking usage 10 simulatable', () => {
+    const [model] = buildValueScalingDisplay([{ type: 27, modifier: 0.06, valueUsage: 10 }], {});
+
+    expect(model).toMatchObject({
+      usage: 10,
+      header: 'Scales with training races won',
+      resolution: 'unsupported',
+      activeTierIndex: 4,
+      trailing: 'best tier pre-applied → 1.2×'
+    });
+    expect(model.rows?.[0].base).toBeCloseTo(0.05);
+    expect(supportedSimulatableValueUsages.has(10)).toBe(false);
+  });
+
+  it('does not build blocks for direct and multiply-random effects', () => {
     expect(
-      resolveActivatedTagCountDisplay({ type: 27, modifier: 0.05 }, { activatedGreenCount: 6 })
-    ).toBe('6 activated greens → 3× → +0.15');
+      buildValueScalingDisplay(
+        [
+          { type: 27, modifier: 0.25, valueUsage: 1 },
+          { type: 9, modifier: 1, valueUsage: 8 }
+        ],
+        {}
+      )
+    ).toEqual([]);
   });
 });

--- a/src/lib/uma-domain/skills/value-scaling/registry.ts
+++ b/src/lib/uma-domain/skills/value-scaling/registry.ts
@@ -1,6 +1,12 @@
 import { activatedTagCountValueScalingDescriptor } from './activated-tag-count';
 import { aoharuTeamStatsValueScalingDescriptor } from './aoharu-team-stats';
-import type { ScalingEffectLike, ValueScalingDescriptor } from './descriptor.types';
+import { climaxRacesWonValueScalingDescriptor } from './climax-races-won';
+import type {
+  ScalingEffectLike,
+  ValueScalingDescriptor,
+  ValueScalingDisplayContext,
+  ValueScalingDisplayModel
+} from './descriptor.types';
 import { directValueScalingDescriptor } from './direct';
 import { multiplyRandomValueScalingDescriptor } from './multiply-random';
 
@@ -8,7 +14,8 @@ const descriptors = [
   directValueScalingDescriptor,
   aoharuTeamStatsValueScalingDescriptor,
   multiplyRandomValueScalingDescriptor,
-  activatedTagCountValueScalingDescriptor
+  activatedTagCountValueScalingDescriptor,
+  climaxRacesWonValueScalingDescriptor
 ] as const;
 
 const descriptorsByUsage = new Map<number, ValueScalingDescriptor>(
@@ -28,4 +35,30 @@ export function describeValueScaling(effect: ScalingEffectLike): string | null {
   return descriptor
     ? descriptor.describe(effect)
     : `Special scaling (usage ${usage}) — not yet simulated`;
+}
+
+export function buildValueScalingDisplay(
+  effects: ReadonlyArray<ScalingEffectLike>,
+  context: ValueScalingDisplayContext
+): ReadonlyArray<ValueScalingDisplayModel> {
+  const effectsByUsage = new Map<number, Array<ScalingEffectLike>>();
+
+  for (const effect of effects) {
+    const usage = effect.valueUsage ?? 1;
+    if (!descriptorsByUsage.get(usage)?.buildDisplay) {
+      continue;
+    }
+
+    const groupedEffects = effectsByUsage.get(usage);
+    if (groupedEffects) {
+      groupedEffects.push(effect);
+    } else {
+      effectsByUsage.set(usage, [effect]);
+    }
+  }
+
+  return Array.from(effectsByUsage, ([usage, groupedEffects]) => {
+    const descriptor = descriptorsByUsage.get(usage);
+    return descriptor?.buildDisplay?.(groupedEffects, context) ?? null;
+  }).filter((model): model is ValueScalingDisplayModel => model !== null);
 }

--- a/src/modules/runners/components/runner-card/runner-card.tsx
+++ b/src/modules/runners/components/runner-card/runner-card.tsx
@@ -2,6 +2,7 @@ import { useCallback, useMemo, useRef } from 'react';
 import { useHotkeys } from 'react-hotkeys-hook';
 
 import { PlusIcon } from 'lucide-react';
+import type { ValueScalingDisplayContext } from '@/lib/uma-domain/skills/value-scaling/descriptor.types';
 import { getUmaDisplayInfo, getUmaImageUrl } from '@/modules/runners/utils';
 import { StatsTable } from './stats-table';
 import { AptitudeBucketsField } from '@/modules/runners/components/aptitude-buckets-field';
@@ -30,6 +31,7 @@ type RunnerCardProps = {
   value: IRunnerState;
   courseDistance?: number;
   runnerId: string;
+  valueScalingContext?: ValueScalingDisplayContext;
 
   // Events
   onChange: (value: IRunnerState) => void;
@@ -60,7 +62,8 @@ export const RunnerCard = (props: RunnerCardProps) => {
     showShareButton = true,
     courseId,
     showStrategyMood = true,
-    skillHotkey
+    skillHotkey,
+    valueScalingContext
   } = props;
 
   const isMobile = useIsMobile();
@@ -265,6 +268,7 @@ export const RunnerCard = (props: RunnerCardProps) => {
           <SkillItem
             key={skillId}
             skillId={skillId}
+            valueScalingContext={valueScalingContext}
             distanceFactor={props.courseDistance}
             costSummary={isSkillSpCostEnabled ? costSummaryBySkillId[skillId] : undefined}
             runnerId={isSkillSpCostEnabled ? props.runnerId : undefined}

--- a/src/modules/runners/components/runners-panel.tsx
+++ b/src/modules/runners/components/runners-panel.tsx
@@ -24,6 +24,7 @@ import {
   type FieldRunner
 } from '@/store/runners.store';
 import { getUmaDisplayInfo } from '@/modules/runners/utils';
+import { useActivatedGreenCount } from '@/modules/runners/hooks/use-activated-green-count';
 import { useCompareSettings } from '@/modules/simulation/stores/compare.store';
 import { useSettingsStore } from '@/store/settings.store';
 
@@ -122,6 +123,11 @@ export const RunnersPanel = () => {
   } = useRunnerLibraryStore();
 
   const course = useMemo(() => coursesService.getSimCourse(courseId), [courseId]);
+  const activatedGreenCount = useActivatedGreenCount({
+    skillIds: runner.skills,
+    strategy: runner.strategy,
+    courseId
+  });
 
   const isLinked = !!runner.linkedRunnerId;
   const linkedRunner = isLinked ? getLibraryRunner(runner.linkedRunnerId!) : null;
@@ -283,6 +289,7 @@ export const RunnersPanel = () => {
             courseDistance={course.distance}
             courseId={courseId}
             runnerId={runnerId}
+            valueScalingContext={{ activatedGreenCount }}
             onChange={updateRunner}
             onReset={resetRunner}
             onCopy={handleCopyRunner}

--- a/src/modules/runners/hooks/use-activated-green-count.ts
+++ b/src/modules/runners/hooks/use-activated-green-count.ts
@@ -1,0 +1,45 @@
+import { useMemo } from 'react';
+import { Strategy, StrategyName, type IStrategyName } from '@/lib/uma-domain/runner/definitions';
+import { countGuaranteedActivatedGreens } from '@/lib/uma-domain/skills/value-scaling/green-activation';
+import { skillsService } from '@/modules/data/services/SkillService';
+import { normalizeSkillIdForCostSummary } from '@/modules/skills/skill-cost-summary';
+import { useSettingsStore } from '@/store/settings.store';
+import { racedefToParams } from '@/utils/races';
+import { coursesService } from '@/modules/data/services/CourseService';
+
+type UseActivatedGreenCountArgs = {
+  skillIds: ReadonlyArray<string>;
+  strategy: IStrategyName;
+  courseId: number;
+};
+
+function strategyForName(strategyName: IStrategyName): number | undefined {
+  return Object.values(Strategy).find((strategy) => StrategyName[strategy] === strategyName);
+}
+
+export function useActivatedGreenCount(args: UseActivatedGreenCountArgs): number | undefined {
+  const { skillIds, strategy, courseId } = args;
+  const racedef = useSettingsStore((state) => state.racedef);
+
+  return useMemo(() => {
+    const strategyValue = strategyForName(strategy);
+    if (strategyValue === undefined) {
+      return undefined;
+    }
+
+    try {
+      const skills = skillIds.flatMap((skillId) => {
+        const skill = skillsService.getById(normalizeSkillIdForCostSummary(skillId));
+        return skill ? [skill] : [];
+      });
+
+      return countGuaranteedActivatedGreens(skills, {
+        runner: { strategy: strategyValue },
+        course: coursesService.getSimCourse(courseId),
+        raceParameters: racedefToParams(racedef)
+      });
+    } catch {
+      return undefined;
+    }
+  }, [courseId, racedef, skillIds, strategy]);
+}

--- a/src/modules/skills/components/ExpandedSkillDetails.tsx
+++ b/src/modules/skills/components/ExpandedSkillDetails.tsx
@@ -1,23 +1,35 @@
 import type { SkillEntry } from '@/modules/data/services/SkillService';
 import type { SkillAlternative } from '@/lib/uma-domain/skills/skill.types';
+import type { ValueScalingDisplayContext } from '@/lib/uma-domain/skills/value-scaling/descriptor.types';
 import { FormatParser, formatEffect } from '@/modules/skills/components/formatters';
 import { HumanReadableParser } from '@/modules/skills/components/human-readable-formatter';
-import { describeValueScaling } from '@/lib/uma-domain/skills/value-scaling/registry';
+import {
+  buildValueScalingDisplay,
+  describeValueScaling
+} from '@/lib/uma-domain/skills/value-scaling/registry';
 import { cn } from '@/lib/utils';
 import i18n from '@/i18n';
 import { Code } from 'lucide-react';
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
 import { SkillIcon } from './skill-list/skill-item/SkillIcon';
+import { SkillScalingBlock } from './skill-scaling-block';
 
 type IAlternativeDetailsProps = {
   alternative: SkillAlternative;
   distanceFactor?: number;
+  valueScalingContext?: ValueScalingDisplayContext;
 };
 
 function AlternativeDetails(props: Readonly<IAlternativeDetailsProps>) {
-  const { alternative, distanceFactor } = props;
+  const { alternative, distanceFactor, valueScalingContext } = props;
   const precondition = alternative.precondition ?? '';
+  const effects = alternative.effects.map((effect) => ({
+    ...effect,
+    modifier: effect.modifier / 10000
+  }));
+  const scalingModels = buildValueScalingDisplay(effects, valueScalingContext ?? {});
+  const structuredScalingUsages = new Set(scalingModels.map((model) => model.usage));
 
   return (
     <div className="flex flex-col text-xs gap-2">
@@ -66,27 +78,39 @@ function AlternativeDetails(props: Readonly<IAlternativeDetailsProps>) {
         {i18n.t('skilldetails.effects')}
 
         <div>
-          {alternative.effects.map((ef, effectIndex) => {
+          {effects.map((ef, effectIndex) => {
             const type = ef.type;
-            const modifier = ef.modifier / 10000;
+            const modifier = ef.modifier;
             const effectType = formatEffect[type as keyof typeof formatEffect];
+            const hasStructuredScaling = structuredScalingUsages.has(ef.valueUsage ?? 1);
             const effectValue =
-              describeValueScaling({ ...ef, modifier }) ??
+              (hasStructuredScaling ? null : describeValueScaling(ef)) ??
               (effectType ? effectType(modifier) : modifier);
             const effectLabel =
               type === 9 && modifier < 0 ? 'HP Drain' : i18n.t(`skilleffecttypes.${type}`);
             const effectKey = `${effectIndex}-${ef.type}-${ef.target}-${ef.modifier}`;
 
             return (
-              <div key={effectKey} className="flex items-center gap-1 py-px">
-                <span className="shrink-0 size-1 rounded-full bg-foreground/40"></span>
-                <span>
-                  {effectLabel}: {effectValue}
-                </span>
+              <div key={effectKey}>
+                <div className="flex items-center gap-1 py-px">
+                  <span className="shrink-0 size-1 rounded-full bg-foreground/40"></span>
+                  <span>
+                    {effectLabel}: {effectValue}
+                  </span>
+                  {hasStructuredScaling && (
+                    <span className="rounded-full border border-border px-1.5 py-px text-[10px] font-medium text-muted-foreground">
+                      scaled
+                    </span>
+                  )}
+                </div>
               </div>
             );
           })}
         </div>
+
+        {scalingModels.map((model) => (
+          <SkillScalingBlock key={model.usage} model={model} />
+        ))}
       </div>
 
       {alternative.baseDuration > 0 && (
@@ -127,11 +151,12 @@ type ExpandedSkillDetailsProps = {
   id: string;
   skill: SkillEntry;
   distanceFactor?: number;
+  valueScalingContext?: ValueScalingDisplayContext;
   className?: string;
 };
 
 export function ExpandedSkillDetails(props: ExpandedSkillDetailsProps) {
-  const { skill: skillData } = props;
+  const { skill: skillData, valueScalingContext } = props;
 
   return (
     <div className={cn('bg-background border-2 rounded-b-sm flex flex-col')}>
@@ -170,6 +195,7 @@ export function ExpandedSkillDetails(props: ExpandedSkillDetailsProps) {
                   <AlternativeDetails
                     alternative={alternative}
                     distanceFactor={props.distanceFactor}
+                    valueScalingContext={valueScalingContext}
                   />
                 </TabsContent>
               );
@@ -179,6 +205,7 @@ export function ExpandedSkillDetails(props: ExpandedSkillDetailsProps) {
           <AlternativeDetails
             alternative={skillData.alternatives[0]}
             distanceFactor={props.distanceFactor}
+            valueScalingContext={valueScalingContext}
           />
         )}
       </div>

--- a/src/modules/skills/components/skill-list/skill-item/actions.tsx
+++ b/src/modules/skills/components/skill-list/skill-item/actions.tsx
@@ -67,7 +67,7 @@ function SkillCostDetailsPopover(props: Readonly<SkillCostDetailsPopoverProps>) 
 
 export function SkillItemDetailsActions(props: Readonly<SkillItemDetailsActionsProps>) {
   const { dismissable = false, onDismiss } = props;
-  const { skill, skillId, distanceFactor, onRemove } = useSkillItem();
+  const { skill, skillId, distanceFactor, valueScalingContext, onRemove } = useSkillItem();
   const [detailsOpen, setDetailsOpen] = useState(false);
 
   return (
@@ -88,7 +88,12 @@ export function SkillItemDetailsActions(props: Readonly<SkillItemDetailsActionsP
 
         {detailsOpen && (
           <PopoverContent align="start" side="right" className="w-[300px] p-0">
-            <ExpandedSkillDetails id={skillId} skill={skill} distanceFactor={distanceFactor} />
+            <ExpandedSkillDetails
+              id={skillId}
+              skill={skill}
+              distanceFactor={distanceFactor}
+              valueScalingContext={valueScalingContext}
+            />
           </PopoverContent>
         )}
       </Popover>

--- a/src/modules/skills/components/skill-list/skill-item/context.ts
+++ b/src/modules/skills/components/skill-list/skill-item/context.ts
@@ -1,4 +1,5 @@
 import { createContext, useContext } from 'react';
+import type { ValueScalingDisplayContext } from '@/lib/uma-domain/skills/value-scaling/descriptor.types';
 import type { SkillEntry } from '@/modules/data/services/SkillService';
 import type { SkillCostSummary } from '@/modules/skills/skill-cost-summary';
 
@@ -15,6 +16,7 @@ export type SkillItemContextValue = {
   skill: SkillEntry;
   skillId: string;
   normalizedSkillId: string;
+  valueScalingContext?: ValueScalingDisplayContext;
   hasFastLearner: boolean;
   hasCost: boolean;
   runnerId?: string;

--- a/src/modules/skills/components/skill-list/skill-item/item.tsx
+++ b/src/modules/skills/components/skill-list/skill-item/item.tsx
@@ -6,6 +6,7 @@ export const SkillItem = React.memo((props: Readonly<SkillItemProps>) => {
   const {
     children,
     skillId,
+    valueScalingContext,
     hasFastLearner,
     distanceFactor,
     spCost,
@@ -20,6 +21,7 @@ export const SkillItem = React.memo((props: Readonly<SkillItemProps>) => {
   return (
     <SkillItemProvider
       skillId={skillId}
+      valueScalingContext={valueScalingContext}
       hasFastLearner={hasFastLearner}
       distanceFactor={distanceFactor}
       spCost={spCost}

--- a/src/modules/skills/components/skill-list/skill-item/provider.tsx
+++ b/src/modules/skills/components/skill-list/skill-item/provider.tsx
@@ -12,19 +12,21 @@ import type { SkillItemContextProps } from './types';
 
 export type SkillItemProviderProps = React.PropsWithChildren<SkillItemContextProps>;
 
-export function SkillItemProvider({
-  children,
-  skillId,
-  hasFastLearner,
-  spCost,
-  runnerId,
-  distanceFactor,
-  costSummary,
-  onHintLevelChange,
-  onBoughtChange,
-  onRemove,
-  getSkillMeta
-}: Readonly<SkillItemProviderProps>) {
+export function SkillItemProvider(props: Readonly<SkillItemProviderProps>) {
+  const {
+    children,
+    skillId,
+    valueScalingContext,
+    hasFastLearner,
+    spCost,
+    runnerId,
+    distanceFactor,
+    costSummary,
+    onHintLevelChange,
+    onBoughtChange,
+    onRemove,
+    getSkillMeta
+  } = props;
   const normalizedSkillId = useMemo(() => normalizeSkillIdForCostSummary(skillId), [skillId]);
 
   const skill = useMemo(() => {
@@ -73,6 +75,7 @@ export function SkillItemProvider({
       skill,
       skillId,
       normalizedSkillId,
+      valueScalingContext,
       hasFastLearner: hasFastLearner ?? false,
       hasCost,
       runnerId,
@@ -88,6 +91,7 @@ export function SkillItemProvider({
     skill,
     skillId,
     normalizedSkillId,
+    valueScalingContext,
     hasFastLearner,
     hasCost,
     runnerId,

--- a/src/modules/skills/components/skill-list/skill-item/types.ts
+++ b/src/modules/skills/components/skill-list/skill-item/types.ts
@@ -1,4 +1,5 @@
 import type { ComponentProps, HTMLAttributes, ReactNode } from 'react';
+import type { ValueScalingDisplayContext } from '@/lib/uma-domain/skills/value-scaling/descriptor.types';
 import type { SkillEntry } from '@/modules/data/services/SkillService';
 import type { SkillCostSummary } from '@/modules/skills/skill-cost-summary';
 import type { SkillMeta } from './context';
@@ -38,6 +39,7 @@ export type SkillItemRailProps = ComponentProps<'div'> & {
 
 export type SkillItemContextProps = {
   skillId: string;
+  valueScalingContext?: ValueScalingDisplayContext;
   distanceFactor?: number;
   spCost?: number;
   costSummary?: SkillCostSummary;

--- a/src/modules/skills/components/skill-scaling-block.test.ts
+++ b/src/modules/skills/components/skill-scaling-block.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest';
+import { roundScalingDisplayValue } from './skill-scaling-block';
+
+describe('roundScalingDisplayValue', () => {
+  it.each([
+    [0.15000000000000002, 0.15],
+    [-0.15000000000000002, -0.15],
+    [0.125, 0.13]
+  ])('rounds %s to a display value of %s', (value, expected) => {
+    expect(roundScalingDisplayValue(value)).toBe(expected);
+  });
+});

--- a/src/modules/skills/components/skill-scaling-block.tsx
+++ b/src/modules/skills/components/skill-scaling-block.tsx
@@ -1,0 +1,110 @@
+import type {
+  ValueScalingDisplayModel,
+  ValueScalingRow
+} from '@/lib/uma-domain/skills/value-scaling/descriptor.types';
+import i18n from '@/i18n';
+import { formatEffect } from './formatters';
+
+type SkillScalingBlockProps = {
+  model: ValueScalingDisplayModel;
+};
+
+export function roundScalingDisplayValue(value: number): number {
+  return Math.round((value + Number.EPSILON) * 100) / 100;
+}
+
+function formatEffectValue(effectType: number, value: number) {
+  const formatter = formatEffect[effectType as keyof typeof formatEffect];
+  const roundedValue = roundScalingDisplayValue(value);
+  return formatter ? formatter(roundedValue) : roundedValue.toString();
+}
+
+function effectLabel(effectType: number, value: number): string {
+  return effectType === 9 && value < 0 ? 'HP Drain' : i18n.t(`skilleffecttypes.${effectType}`);
+}
+
+function ScalingRow(props: { row: ValueScalingRow }) {
+  const { row } = props;
+
+  return (
+    <div className="flex flex-wrap items-baseline justify-between gap-x-2 gap-y-0.5 font-mono text-[11px]">
+      <span className="font-sans text-muted-foreground">
+        {effectLabel(row.effectType, row.result)}
+      </span>
+      <span>
+        {formatEffectValue(row.effectType, row.base)} × {row.multiplier}× ={' '}
+        <span className="font-medium text-foreground">
+          {formatEffectValue(row.effectType, row.result)}
+        </span>
+      </span>
+    </div>
+  );
+}
+
+export function SkillScalingBlock(props: Readonly<SkillScalingBlockProps>) {
+  const { model } = props;
+
+  return (
+    <section
+      aria-label="Special scaling"
+      className="mt-2 rounded-md border border-border bg-muted/30 p-2 text-xs"
+      data-resolution={model.resolution}
+    >
+      <div className="mb-1.5 flex items-baseline justify-between gap-2">
+        <div>
+          <div className="text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+            Special scaling
+          </div>
+          <div className="font-medium">{model.header}</div>
+        </div>
+        {model.trailing && (
+          <span className="shrink-0 font-mono text-[11px] text-muted-foreground">
+            {model.trailing}
+          </span>
+        )}
+      </div>
+
+      {model.tiers && (
+        <div className="mb-1.5 grid grid-flow-col auto-cols-fr overflow-hidden rounded-sm border border-border">
+          {model.tiers.map((tier, index) => {
+            const isActive = index === model.activeTierIndex;
+
+            return (
+              <div
+                key={tier.label}
+                aria-current={isActive ? 'true' : undefined}
+                className="min-w-0 border-l border-border px-1 py-1 text-center first:border-l-0"
+                data-active={isActive || undefined}
+              >
+                <div className={isActive ? 'font-medium text-foreground' : 'text-muted-foreground'}>
+                  {tier.label}
+                </div>
+                <div
+                  className={isActive ? 'font-mono font-medium' : 'font-mono text-muted-foreground'}
+                >
+                  {tier.multiplier}×
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {model.rows && (
+        <div className="space-y-1 border-t border-border pt-1.5">
+          {model.rows.map((row) => (
+            <ScalingRow key={`${row.effectType}-${row.base}`} row={row} />
+          ))}
+        </div>
+      )}
+
+      {model.notes && (
+        <div className="mt-1.5 space-y-0.5 text-[11px] leading-snug text-muted-foreground">
+          {model.notes.map((note) => (
+            <p key={note}>{note}</p>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}


### PR DESCRIPTION
Shows how special-scaling skills resolve without burying the base value in tooltip prose. Compare runners now expose the race-aware activated-green tier; static scenario scaling remains explicit about the extract's best-tier assumption.

## Flow
```mermaid
flowchart LR
  Runner["Compare runner skills and race settings"] --> GreenCount["Guaranteed activated-green count"]
  GreenCount --> DisplayModel["Value scaling display model"]
  SkillEffects["Skill effects grouped by value usage"] --> DisplayModel
  DisplayModel --> Tooltip["Special scaling tooltip block"]
```

## What's here
- `src/lib/uma-domain/skills/value-scaling/` — structured display models for activated greens, Aoharu team stats, and Climax races won.
- `src/modules/runners/hooks/use-activated-green-count.ts` — derives compare-runner green activation context from the selected race.
- `src/modules/skills/components/skill-scaling-block.tsx` — renders tiers and base × multiplier = result rows, rounded to two decimals.
- `docs/mechanics/` and `packages/uma-sim-primitives/` — correct Aoharu TT/CM canon and document the pre-applied 1.2× extract behavior.

## Gates
- `pnpm run typecheck` ✅
- `pnpm run test` ✅ — 423 tests
- `pnpm run lint` ✅ — 0 errors (181 existing warnings)
- `pnpm run intent` ✅
- `cargo test -p uma-sim-primitives` ✅ — 211 tests

## Caveat
Scenario skills continue to use the extractor's pre-applied 1.2× best-tier assumption. This PR makes that visible; it does not add sub-3600 team runtime modeling.

Docs: `docs/mechanics/README.md` — Aoharu Skills (3-7)