### PR TITLE
feat(runners): import umadump veterans

### DIFF
--- a/src/modules/runners/roster/components/filter-row-slot.test.tsx
+++ b/src/modules/runners/roster/components/filter-row-slot.test.tsx
@@ -1,0 +1,26 @@
+// @vitest-environment jsdom
+
+import '@testing-library/jest-dom/vitest';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { AptitudeFilterRowSlot } from './filter-row-slot';
+
+const slot = { key: 'proper_ground_turf', name: 'Turf' } as const;
+
+describe('AptitudeFilterRowSlot', () => {
+  it('reflects controlled filter changes in the visible trigger label', () => {
+    const onChange = vi.fn();
+    const { rerender } = render(
+      <AptitudeFilterRowSlot slot={slot} filters={{}} onChange={onChange} />
+    );
+
+    expect(screen.getByRole('combobox')).toHaveTextContent('All');
+
+    rerender(
+      <AptitudeFilterRowSlot slot={slot} filters={{ proper_ground_turf: 7 }} onChange={onChange} />
+    );
+
+    expect(screen.getByRole('combobox')).toHaveTextContent('A');
+    expect(screen.getByRole('combobox')).not.toHaveTextContent('7');
+  });
+});

--- a/src/modules/runners/roster/components/filter-row-slot.tsx
+++ b/src/modules/runners/roster/components/filter-row-slot.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react';
+import { useCallback } from 'react';
 import { IAptitudeFilters, IAptitudeSlotKey } from '../types';
 import {
   Select,
@@ -19,10 +19,9 @@ type IAptitudeFilterRowSlotProps = {
 export const AptitudeFilterRowSlot = (props: Readonly<IAptitudeFilterRowSlotProps>) => {
   const { slot, filters, onChange } = props;
 
-  const [value] = useState<string>(() => {
-    const current = filters[slot.key];
-    return current !== undefined && current !== null ? String(current) : 'any';
-  });
+  const current = filters[slot.key];
+  const value = current !== undefined && current !== null ? String(current) : 'any';
+  const label = current !== undefined && current !== null ? encodingToAptitude(current) : 'All';
 
   const onValueChange = useCallback(
     (v: string | null) => {
@@ -42,7 +41,7 @@ export const AptitudeFilterRowSlot = (props: Readonly<IAptitudeFilterRowSlotProp
 
       <Select value={value} onValueChange={onValueChange}>
         <SelectTrigger size="sm" className="w-auto min-w-18 gap-1 text-xs">
-          <SelectValue />
+          <SelectValue>{label}</SelectValue>
         </SelectTrigger>
 
         <SelectContent className="text-xs">

--- a/src/modules/runners/roster/components/import-runner-picker.tsx
+++ b/src/modules/runners/roster/components/import-runner-picker.tsx
@@ -1,0 +1,279 @@
+import type { ReactNode } from 'react';
+import { useCallback, useMemo, useReducer, useRef } from 'react';
+import { useVirtualizer } from '@tanstack/react-virtual';
+import { Search, X } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
+import { DialogFooter } from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { useIsMobile } from '@/hooks/use-mobile';
+import { hasAnyAptitudeFilter, passesAptitudeFilters } from '../helpers';
+import { DESKTOP_ROW_HEIGHT, MOBILE_ROW_HEIGHT } from '../constants';
+import type { IAptitudeFilters, IAptitudeSlotKey, IDecodedRunner } from '../types';
+import { AptitudeFilterGrid } from './filter-grid';
+import { RunnerRow } from './runner-row';
+
+type PickerState = {
+  selected: Set<number>;
+  search: string;
+  aptFilters: IAptitudeFilters;
+};
+
+type PickerAction =
+  | { type: 'search:set'; value: string }
+  | { type: 'filters:clear' }
+  | { type: 'selection:toggle'; index: number }
+  | { type: 'selection:select-many'; indices: number[] }
+  | { type: 'selection:deselect-many'; indices: number[] }
+  | { type: 'filters:aptitude:set'; key: IAptitudeSlotKey; value: number | null };
+
+const EMPTY_DISABLED_INDICES: ReadonlySet<number> = new Set();
+
+type ImportRunnerPickerProps = {
+  runners: IDecodedRunner[];
+  sourceContent: ReactNode;
+  initialSelectedIndices?: number[];
+  disabledIndices?: ReadonlySet<number>;
+  onCancel: () => void;
+  onImport: (runners: IDecodedRunner[]) => void;
+};
+
+function createPickerState(initialSelectedIndices: number[]): PickerState {
+  return {
+    selected: new Set(initialSelectedIndices),
+    search: '',
+    aptFilters: {}
+  };
+}
+
+function pickerReducer(state: PickerState, action: PickerAction): PickerState {
+  switch (action.type) {
+    case 'search:set':
+      return { ...state, search: action.value };
+    case 'filters:clear':
+      return { ...state, search: '', aptFilters: {} };
+    case 'selection:toggle': {
+      const selected = new Set(state.selected);
+      if (selected.has(action.index)) selected.delete(action.index);
+      else selected.add(action.index);
+      return { ...state, selected };
+    }
+    case 'selection:select-many': {
+      const selected = new Set(state.selected);
+      for (const index of action.indices) selected.add(index);
+      return { ...state, selected };
+    }
+    case 'selection:deselect-many': {
+      const selected = new Set(state.selected);
+      for (const index of action.indices) selected.delete(index);
+      return { ...state, selected };
+    }
+    case 'filters:aptitude:set': {
+      const aptFilters = { ...state.aptFilters };
+      if (action.value == null) delete aptFilters[action.key];
+      else aptFilters[action.key] = action.value;
+      return { ...state, aptFilters };
+    }
+    default: {
+      const exhaustiveAction: never = action;
+      return exhaustiveAction;
+    }
+  }
+}
+
+export function ImportRunnerPicker(props: Readonly<ImportRunnerPickerProps>) {
+  const {
+    runners,
+    sourceContent,
+    initialSelectedIndices = runners.map((_, index) => index),
+    disabledIndices = EMPTY_DISABLED_INDICES,
+    onCancel,
+    onImport
+  } = props;
+
+  const [state, dispatch] = useReducer(pickerReducer, initialSelectedIndices, createPickerState);
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const isMobile = useIsMobile();
+  const hasActiveAptFilter = hasAnyAptitudeFilter(state.aptFilters);
+
+  const filtered = useMemo(() => {
+    const query = state.search.toLowerCase().trim();
+    return runners.reduce<Array<{ runner: IDecodedRunner; index: number }>>(
+      (items, runner, index) => {
+        if (query && !runner.searchText.includes(query)) return items;
+        if (hasActiveAptFilter && !passesAptitudeFilters(runner.source, state.aptFilters)) {
+          return items;
+        }
+        items.push({ runner, index });
+        return items;
+      },
+      []
+    );
+  }, [runners, state.search, state.aptFilters, hasActiveAptFilter]);
+
+  const selectableFiltered = useMemo(
+    () => filtered.filter(({ index }) => !disabledIndices.has(index)),
+    [disabledIndices, filtered]
+  );
+  const filteredSelectedCount = useMemo(
+    () => selectableFiltered.filter(({ index }) => state.selected.has(index)).length,
+    [selectableFiltered, state.selected]
+  );
+  const allFilteredSelected =
+    selectableFiltered.length > 0 && filteredSelectedCount === selectableFiltered.length;
+  const someFilteredSelected = filteredSelectedCount > 0 && !allFilteredSelected;
+  const hasActiveFilters = !!state.search.trim() || hasActiveAptFilter;
+
+  const virtualizer = useVirtualizer({
+    count: filtered.length,
+    getScrollElement: () => scrollRef.current,
+    estimateSize: () => (isMobile ? MOBILE_ROW_HEIGHT : DESKTOP_ROW_HEIGHT),
+    overscan: 15,
+    getItemKey: (index) => {
+      const item = filtered[index];
+      return `${item.runner.source.card_id}-${item.index}`;
+    }
+  });
+
+  const selectAllFiltered = useCallback(() => {
+    dispatch({
+      type: 'selection:select-many',
+      indices: selectableFiltered.map(({ index }) => index)
+    });
+  }, [selectableFiltered]);
+
+  const deselectAllFiltered = useCallback(() => {
+    dispatch({
+      type: 'selection:deselect-many',
+      indices: selectableFiltered.map(({ index }) => index)
+    });
+  }, [selectableFiltered]);
+
+  const toggleOne = useCallback(
+    (index: number) => {
+      if (!disabledIndices.has(index)) dispatch({ type: 'selection:toggle', index });
+    },
+    [disabledIndices]
+  );
+
+  const selectedRunners = useMemo(
+    () => runners.filter((_, index) => state.selected.has(index) && !disabledIndices.has(index)),
+    [disabledIndices, runners, state.selected]
+  );
+
+  return (
+    <>
+      <div className="flex flex-col gap-4 md:flex-row">
+        <div className="flex flex-col gap-3 md:w-80 md:shrink-0">
+          {sourceContent}
+
+          <div className="flex flex-col gap-2">
+            <div className="relative">
+              <Search className="absolute left-2.5 top-1/2 size-3.5 -translate-y-1/2 text-muted-foreground" />
+              <Input
+                aria-label="Search imported characters"
+                placeholder="Search characters..."
+                value={state.search}
+                onChange={(event) => dispatch({ type: 'search:set', value: event.target.value })}
+                className="pl-8"
+              />
+            </div>
+
+            <div className="hidden md:block">
+              <AptitudeFilterGrid
+                filters={state.aptFilters}
+                onChange={(key, value) => dispatch({ type: 'filters:aptitude:set', key, value })}
+              />
+            </div>
+
+            <div className="flex items-center gap-2">
+              <Checkbox
+                aria-label="Select all visible runners"
+                checked={allFilteredSelected}
+                indeterminate={someFilteredSelected}
+                disabled={selectableFiltered.length === 0}
+                onCheckedChange={(checked) => {
+                  if (checked) selectAllFiltered();
+                  else deselectAllFiltered();
+                }}
+              />
+
+              <button
+                type="button"
+                className="cursor-pointer text-xs text-muted-foreground transition-colors hover:text-foreground disabled:cursor-default disabled:opacity-50"
+                disabled={selectableFiltered.length === 0}
+                onClick={() => {
+                  if (allFilteredSelected) deselectAllFiltered();
+                  else selectAllFiltered();
+                }}
+              >
+                {hasActiveFilters
+                  ? `Select all ${selectableFiltered.length} matching`
+                  : `Select all ${runners.length - disabledIndices.size}`}
+              </button>
+
+              {hasActiveFilters && (
+                <button
+                  type="button"
+                  className="ml-auto flex cursor-pointer items-center gap-1 text-xs text-muted-foreground transition-colors hover:text-foreground"
+                  onClick={() => dispatch({ type: 'filters:clear' })}
+                >
+                  <X className="size-3" />
+                  Clear filters
+                </button>
+              )}
+            </div>
+
+            <div className="text-xs text-muted-foreground">
+              {selectedRunners.length}/{runners.length - disabledIndices.size} available selected
+              {hasActiveFilters && ` · ${filtered.length} shown`}
+            </div>
+          </div>
+        </div>
+
+        <div className="flex min-w-0 flex-1 flex-col gap-1">
+          <div ref={scrollRef} className="max-h-96 overflow-y-auto md:h-128 md:max-h-none">
+            <div className="relative w-full" style={{ height: virtualizer.getTotalSize() }}>
+              {virtualizer.getVirtualItems().map((virtualRow) => {
+                const { runner, index } = filtered[virtualRow.index];
+                return (
+                  <div
+                    key={virtualRow.key}
+                    className="absolute left-0 w-full"
+                    style={{
+                      height: isMobile ? MOBILE_ROW_HEIGHT : DESKTOP_ROW_HEIGHT,
+                      transform: `translateY(${virtualRow.start}px)`
+                    }}
+                  >
+                    <RunnerRow
+                      runner={runner}
+                      index={index}
+                      isSelected={state.selected.has(index)}
+                      disabled={disabledIndices.has(index)}
+                      onToggle={toggleOne}
+                    />
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+
+          {filtered.length === 0 && hasActiveFilters && (
+            <div className="p-4 text-center text-sm text-muted-foreground">
+              No characters match the current filters
+            </div>
+          )}
+        </div>
+      </div>
+
+      <DialogFooter>
+        <Button variant="outline" onClick={onCancel}>
+          Cancel
+        </Button>
+        <Button onClick={() => onImport(selectedRunners)} disabled={selectedRunners.length === 0}>
+          Import{selectedRunners.length > 0 ? ` (${selectedRunners.length})` : ''}
+        </Button>
+      </DialogFooter>
+    </>
+  );
+}

--- a/src/modules/runners/roster/components/runner-row.tsx
+++ b/src/modules/runners/roster/components/runner-row.tsx
@@ -16,24 +16,31 @@ type IRunnerRowProps = Readonly<{
   runner: IDecodedRunner;
   index: number;
   isSelected: boolean;
+  disabled?: boolean;
   onToggle: (index: number) => void;
 }>;
 
 export const RunnerRow = memo(function RunnerRow(props: Readonly<IRunnerRowProps>) {
-  const { runner, index, isSelected, onToggle } = props;
+  const { runner, index, isSelected, disabled = false, onToggle } = props;
 
   const runnerSource = runner.source;
 
   return (
     <button
       type="button"
-      className={`flex items-center gap-3 p-2 border rounded-md text-left transition-colors cursor-pointer w-full ${
-        isSelected ? 'border-primary/40 bg-primary/5' : 'opacity-50 hover:opacity-80'
+      className={`flex w-full items-center gap-3 rounded-md border p-2 text-left transition-colors ${
+        disabled
+          ? 'cursor-default opacity-50'
+          : isSelected
+            ? 'cursor-pointer border-primary/40 bg-primary/5'
+            : 'cursor-pointer opacity-50 hover:opacity-80'
       }`}
+      disabled={disabled}
       onClick={() => onToggle(index)}
     >
       <Checkbox
         checked={isSelected}
+        disabled={disabled}
         onCheckedChange={() => onToggle(index)}
         onClick={(e) => e.stopPropagation()}
       />
@@ -102,8 +109,8 @@ export const RunnerRow = memo(function RunnerRow(props: Readonly<IRunnerRowProps
             <AptGrade value={runnerSource.proper_running_style_oikomi} />
           </div>
 
-          <span className="text-xs text-muted-foreground ml-auto">
-            {runner.state.skills.length} skills
+          <span className="ml-auto text-xs text-muted-foreground">
+            {disabled ? 'Already saved' : `${runner.state.skills.length} skills`}
           </span>
         </div>
       </div>

--- a/src/modules/runners/roster/import-dialog.tsx
+++ b/src/modules/runners/roster/import-dialog.tsx
@@ -1,3 +1,5 @@
+import { useCallback, useEffect, useState } from 'react';
+import { toast } from 'sonner';
 import { Button } from '@/components/ui/button';
 import {
   Dialog,
@@ -7,196 +9,45 @@ import {
   DialogHeader,
   DialogTitle
 } from '@/components/ui/dialog';
-import { useCallback, useEffect, useMemo, useReducer, useRef, useState } from 'react';
-import { IAptitudeFilters, IAptitudeSlotKey, IDecodedRunner } from './types';
 import { decodeRoster } from '../share/roster-encoding';
-import { buildDecodedRunner, hasAnyAptitudeFilter, passesAptitudeFilters } from './helpers';
-import { useIsMobile } from '@/hooks/use-mobile';
-import { useVirtualizer } from '@tanstack/react-virtual';
-import { ISavedRunner, useRunnerLibraryStore } from '@/store/runner-library.store';
-import { toast } from 'sonner';
-import { Search, X } from 'lucide-react';
-import { Input } from '@/components/ui/input';
-import { AptitudeFilterGrid } from './components/filter-grid';
-import { Checkbox } from '@/components/ui/checkbox';
-import { RunnerRow } from './components/runner-row';
-import { DESKTOP_ROW_HEIGHT, MOBILE_ROW_HEIGHT } from './constants';
+import { ImportRunnerPicker } from './components/import-runner-picker';
+import { buildDecodedRunner } from './helpers';
+import { appendVeteransToLibrary } from './import-library';
+import type { IDecodedRunner } from './types';
 
-type IRosterImportDialogProps = {
+type RosterImportDialogProps = {
   open: boolean;
   onOpenChange: (open: boolean) => void;
 };
 
-type ImportStateBase = {
-  selected: Set<number>;
-  search: string;
-  aptFilters: IAptitudeFilters;
-};
+type DecodeResult =
+  | { code: string; status: 'error'; runners: null }
+  | { code: string; status: 'decoded'; runners: IDecodedRunner[] };
 
-type ImportState =
-  | (ImportStateBase & {
-      status: 'idle';
-      runners: null;
-    })
-  | (ImportStateBase & {
-      status: 'loading';
-      runners: IDecodedRunner[] | null;
-    })
-  | (ImportStateBase & {
-      status: 'error';
-      runners: null;
-    })
-  | (ImportStateBase & {
-      status: 'decoded';
-      runners: IDecodedRunner[];
-    });
+type DecodeState =
+  | { status: 'idle'; runners: null }
+  | { status: 'loading'; runners: null }
+  | DecodeResult;
 
-type ImportAction =
-  | { type: 'reset' }
-  | { type: 'decode:start' }
-  | { type: 'decode:success'; runners: IDecodedRunner[] }
-  | { type: 'decode:error' }
-  | { type: 'search:set'; value: string }
-  | { type: 'filters:clear' }
-  | { type: 'selection:toggle'; index: number }
-  | { type: 'selection:select-many'; indices: number[] }
-  | { type: 'selection:deselect-many'; indices: number[] }
-  | {
-      type: 'filters:aptitude:set';
-      key: IAptitudeSlotKey;
-      value: number | null;
-    };
-
-function createInitialImportState(): ImportState {
-  return {
-    status: 'idle',
-    runners: null,
-    selected: new Set(),
-    search: '',
-    aptFilters: {}
-  };
-}
-
-function importReducer(state: ImportState, action: ImportAction): ImportState {
-  switch (action.type) {
-    case 'reset':
-      return createInitialImportState();
-    case 'decode:start':
-      return {
-        ...state,
-        status: 'loading'
-      };
-    case 'decode:success':
-      return {
-        status: 'decoded',
-        runners: action.runners,
-        selected: new Set(action.runners.map((_, index) => index)),
-        search: '',
-        aptFilters: {}
-      };
-    case 'decode:error':
-      return {
-        status: 'error',
-        runners: null,
-        selected: new Set(),
-        search: state.search,
-        aptFilters: state.aptFilters
-      };
-    case 'search:set':
-      return {
-        ...state,
-        search: action.value
-      };
-    case 'filters:clear':
-      return {
-        ...state,
-        search: '',
-        aptFilters: {}
-      };
-    case 'selection:toggle': {
-      const nextSelected = new Set(state.selected);
-
-      if (nextSelected.has(action.index)) {
-        nextSelected.delete(action.index);
-      } else {
-        nextSelected.add(action.index);
-      }
-
-      return {
-        ...state,
-        selected: nextSelected
-      };
-    }
-    case 'selection:select-many': {
-      const nextSelected = new Set(state.selected);
-
-      for (const index of action.indices) {
-        nextSelected.add(index);
-      }
-
-      return {
-        ...state,
-        selected: nextSelected
-      };
-    }
-    case 'selection:deselect-many': {
-      const nextSelected = new Set(state.selected);
-
-      for (const index of action.indices) {
-        nextSelected.delete(index);
-      }
-
-      return {
-        ...state,
-        selected: nextSelected
-      };
-    }
-    case 'filters:aptitude:set': {
-      const nextFilters = { ...state.aptFilters };
-
-      if (action.value == null) {
-        delete nextFilters[action.key];
-      } else {
-        nextFilters[action.key] = action.value;
-      }
-
-      return {
-        ...state,
-        aptFilters: nextFilters
-      };
-    }
-    default: {
-      const exhaustiveAction: never = action;
-      return exhaustiveAction;
-    }
-  }
-}
-
-export function RosterImportDialog({ open, onOpenChange }: Readonly<IRosterImportDialogProps>) {
+export function RosterImportDialog(props: Readonly<RosterImportDialogProps>) {
+  const { open, onOpenChange } = props;
   const [code, setCode] = useState('');
-  const [importState, dispatch] = useReducer(importReducer, undefined, createInitialImportState);
-  const scrollRef = useRef<HTMLDivElement>(null);
+  const [decodeResult, setDecodeResult] = useState<DecodeResult | null>(null);
+  const trimmedCode = code.trim();
 
   useEffect(() => {
-    const trimmed = code.trim();
-    if (!trimmed) {
-      dispatch({ type: 'reset' });
-      return;
-    }
+    if (!trimmedCode) return;
 
     let cancelled = false;
-    dispatch({ type: 'decode:start' });
-
-    decodeRoster(trimmed).then((result) => {
+    void decodeRoster(trimmedCode).then((result) => {
       if (cancelled) return;
-
-      if (!result) {
-        dispatch({ type: 'decode:error' });
+      if (!result || result.length === 0) {
+        setDecodeResult({ code: trimmedCode, status: 'error', runners: null });
         return;
       }
-
-      dispatch({
-        type: 'decode:success',
+      setDecodeResult({
+        code: trimmedCode,
+        status: 'decoded',
         runners: result.map(buildDecodedRunner)
       });
     });
@@ -204,118 +55,54 @@ export function RosterImportDialog({ open, onOpenChange }: Readonly<IRosterImpor
     return () => {
       cancelled = true;
     };
-  }, [code]);
+  }, [trimmedCode]);
 
-  const decoded = importState.runners;
-  const error = importState.status === 'error';
-  const loading = importState.status === 'loading';
-  const selected = importState.selected;
-  const search = importState.search;
-  const aptFilters = importState.aptFilters;
+  const decodeState: DecodeState = !trimmedCode
+    ? { status: 'idle', runners: null }
+    : decodeResult?.code === trimmedCode
+      ? decodeResult
+      : { status: 'loading', runners: null };
 
-  const hasActiveAptFilter = hasAnyAptitudeFilter(aptFilters);
-
-  const filtered = useMemo(() => {
-    if (!decoded) return [];
-    const query = search.toLowerCase().trim();
-
-    return decoded.reduce<Array<{ runner: IDecodedRunner; index: number }>>((acc, runner, i) => {
-      if (query && !runner.searchText.includes(query)) return acc;
-      if (hasActiveAptFilter && !passesAptitudeFilters(runner.source, aptFilters)) return acc;
-      acc.push({ runner, index: i });
-      return acc;
-    }, []);
-  }, [decoded, search, aptFilters, hasActiveAptFilter]);
-
-  const filteredSelectedCount = useMemo(
-    () => filtered.filter((f) => selected.has(f.index)).length,
-    [filtered, selected]
-  );
-
-  const isMobile = useIsMobile();
-
-  const virtualizer = useVirtualizer({
-    count: filtered.length,
-    getScrollElement: () => scrollRef.current,
-    estimateSize: () => (isMobile ? MOBILE_ROW_HEIGHT : DESKTOP_ROW_HEIGHT),
-    overscan: 15,
-    getItemKey: (index) => {
-      const item = filtered[index];
-      return `${item.runner.source.card_id}-${item.index}`;
-    }
-  });
+  const reset = useCallback(() => {
+    setCode('');
+    setDecodeResult(null);
+  }, []);
 
   const handleOpenChange = useCallback(
     (next: boolean) => {
-      if (!next) {
-        setCode('');
-        dispatch({ type: 'reset' });
-      }
+      if (!next) reset();
       onOpenChange(next);
     },
-    [onOpenChange]
+    [onOpenChange, reset]
   );
 
-  const toggleOne = useCallback((index: number) => {
-    dispatch({ type: 'selection:toggle', index });
-  }, []);
+  const handleImport = useCallback(
+    (runners: IDecodedRunner[]) => {
+      const count = appendVeteransToLibrary(
+        runners.map((runner) => ({ state: runner.state, notes: 'Imported from RosterView' }))
+      );
+      toast.success(`Imported ${count} runner${count === 1 ? '' : 's'} to Veterans`);
+      handleOpenChange(false);
+    },
+    [handleOpenChange]
+  );
 
-  const selectAllFiltered = useCallback(() => {
-    dispatch({
-      type: 'selection:select-many',
-      indices: filtered.map(({ index }) => index)
-    });
-  }, [filtered]);
+  const sourceContent = (
+    <>
+      <label htmlFor="rosterview-roster-code" className="text-xs font-medium text-muted-foreground">
+        RosterView code
+      </label>
+      <textarea
+        id="rosterview-roster-code"
+        className="h-24 w-full resize-none rounded-md border bg-background p-3 font-mono text-sm focus:outline-none focus:ring-2 focus:ring-primary"
+        placeholder="Paste a RosterView roster code..."
+        value={code}
+        onChange={(event) => setCode(event.target.value)}
+      />
+    </>
+  );
 
-  const deselectAllFiltered = useCallback(() => {
-    dispatch({
-      type: 'selection:deselect-many',
-      indices: filtered.map(({ index }) => index)
-    });
-  }, [filtered]);
-
-  const setAptFilter = useCallback((key: IAptitudeSlotKey, value: number | null) => {
-    dispatch({ type: 'filters:aptitude:set', key, value });
-  }, []);
-
-  const allFilteredSelected = filtered.length > 0 && filteredSelectedCount === filtered.length;
-  const someFilteredSelected = filteredSelectedCount > 0 && !allFilteredSelected;
-  const hasActiveFilters = !!search.trim() || hasActiveAptFilter;
-
-  const clearAllFilters = useCallback(() => {
-    dispatch({ type: 'filters:clear' });
-  }, []);
-
-  const handleImportSelected = useCallback(() => {
-    if (!decoded || selected.size === 0) return;
-
-    const now = Date.now();
-    const newRunners: ISavedRunner[] = [];
-    let idx = 0;
-
-    for (const i of selected) {
-      const runner = decoded[i];
-      newRunners.push({
-        ...runner.state,
-        notes: 'Imported from RosterView',
-        id: `${now}-${idx}-${Math.random().toString(36).slice(2, 9)}`,
-        createdAt: now,
-        updatedAt: now
-      });
-      idx++;
-    }
-
-    useRunnerLibraryStore.setState((state) => ({
-      runners: [...state.runners, ...newRunners]
-    }));
-
-    toast.success(
-      `Imported ${newRunners.length} runner${newRunners.length === 1 ? '' : 's'} to library`
-    );
-    handleOpenChange(false);
-  }, [decoded, selected, handleOpenChange]);
-
-  const hasResults = decoded && decoded.length > 0;
+  const hasResults = decodeState.status === 'decoded';
 
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
@@ -323,140 +110,45 @@ export function RosterImportDialog({ open, onOpenChange }: Readonly<IRosterImpor
         className={`max-h-[calc(100dvh-2rem)] overflow-y-auto ${hasResults ? 'max-w-5xl!' : 'max-w-2xl!'}`}
       >
         <DialogHeader>
-          <DialogTitle>Import Full Roster</DialogTitle>
+          <DialogTitle>Import RosterView code</DialogTitle>
           <DialogDescription>
-            Paste an encoded roster string to import multiple runners at once.
+            Paste an encoded roster code, then choose the runners to add to Veterans.
           </DialogDescription>
         </DialogHeader>
 
-        <div className={hasResults ? 'flex flex-col md:flex-row gap-4' : 'flex flex-col gap-3'}>
-          {/* Left panel: input + filters */}
-          <div className={`flex flex-col gap-3 ${hasResults ? 'md:w-80 md:shrink-0' : ''}`}>
-            <textarea
-              className="w-full h-24 p-3 rounded-md border bg-background font-mono text-sm resize-none focus:outline-none focus:ring-2 focus:ring-primary"
-              placeholder="Paste RosterView roster code here..."
-              value={code}
-              onChange={(e) => setCode(e.target.value)}
-            />
-
-            {loading && (
-              <div className="p-3 text-sm text-muted-foreground text-center">Decoding roster…</div>
-            )}
-
-            {error && !loading && (
-              <div className="p-3 bg-destructive/10 border border-destructive/30 rounded-md text-destructive text-sm">
-                Invalid roster code. Please check the code and try again.
-              </div>
-            )}
-
-            {hasResults && (
-              <div className="flex flex-col gap-2">
-                <div className="relative">
-                  <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 size-3.5 text-muted-foreground" />
-                  <Input
-                    placeholder="Search characters..."
-                    value={search}
-                    onChange={(e) => dispatch({ type: 'search:set', value: e.target.value })}
-                    className="pl-8"
-                  />
+        {hasResults ? (
+          <ImportRunnerPicker
+            key={code}
+            runners={decodeState.runners}
+            sourceContent={sourceContent}
+            onCancel={() => handleOpenChange(false)}
+            onImport={handleImport}
+          />
+        ) : (
+          <>
+            <div className="flex flex-col gap-3">
+              {sourceContent}
+              {decodeState.status === 'loading' && (
+                <div role="status" className="p-3 text-center text-sm text-muted-foreground">
+                  Decoding roster…
                 </div>
-
-                <div className="hidden md:block">
-                  <AptitudeFilterGrid filters={aptFilters} onChange={setAptFilter} />
-                </div>
-
-                <div className="flex items-center gap-2">
-                  <Checkbox
-                    checked={allFilteredSelected}
-                    indeterminate={someFilteredSelected}
-                    onCheckedChange={(checked) => {
-                      if (checked) selectAllFiltered();
-                      else deselectAllFiltered();
-                    }}
-                  />
-
-                  <button
-                    type="button"
-                    className="text-xs text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
-                    onClick={() => {
-                      if (allFilteredSelected) deselectAllFiltered();
-                      else selectAllFiltered();
-                    }}
-                  >
-                    {hasActiveFilters
-                      ? `Select all ${filtered.length} matching`
-                      : `Select all ${decoded.length}`}
-                  </button>
-
-                  {hasActiveFilters && (
-                    <button
-                      type="button"
-                      className="ml-auto flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
-                      onClick={clearAllFilters}
-                    >
-                      <X className="size-3" />
-                      Clear filters
-                    </button>
-                  )}
-                </div>
-
-                <div className="text-xs text-muted-foreground">
-                  {selected.size}/{decoded.length} selected
-                  {hasActiveFilters && ` · ${filtered.length} shown`}
-                </div>
-              </div>
-            )}
-          </div>
-
-          {/* Right panel: character list */}
-          {hasResults && (
-            <div className="flex flex-col gap-1 flex-1 min-w-0">
-              <div ref={scrollRef} className="overflow-y-auto max-h-96 md:max-h-none md:h-128">
-                <div className="relative w-full" style={{ height: virtualizer.getTotalSize() }}>
-                  {virtualizer.getVirtualItems().map((virtualRow) => {
-                    const { runner, index } = filtered[virtualRow.index];
-
-                    return (
-                      <div
-                        key={virtualRow.key}
-                        className="absolute left-0 w-full"
-                        style={{
-                          height: isMobile ? MOBILE_ROW_HEIGHT : DESKTOP_ROW_HEIGHT,
-                          transform: `translateY(${virtualRow.start}px)`
-                        }}
-                      >
-                        <RunnerRow
-                          runner={runner}
-                          index={index}
-                          isSelected={selected.has(index)}
-                          onToggle={toggleOne}
-                        />
-                      </div>
-                    );
-                  })}
-                </div>
-              </div>
-
-              {filtered.length === 0 && hasActiveFilters && (
-                <div className="p-4 text-sm text-muted-foreground text-center">
-                  No characters match the current filters
+              )}
+              {decodeState.status === 'error' && (
+                <div
+                  role="alert"
+                  className="rounded-md border border-destructive/30 bg-destructive/10 p-3 text-sm text-destructive"
+                >
+                  This roster code could not be decoded. Check that you copied the complete code.
                 </div>
               )}
             </div>
-          )}
-        </div>
-
-        <DialogFooter>
-          <Button variant="outline" onClick={() => handleOpenChange(false)}>
-            Cancel
-          </Button>
-
-          {hasResults && (
-            <Button onClick={handleImportSelected} disabled={selected.size === 0}>
-              Import{selected.size > 0 ? ` (${selected.size})` : ''}
-            </Button>
-          )}
-        </DialogFooter>
+            <DialogFooter>
+              <Button variant="outline" onClick={() => handleOpenChange(false)}>
+                Cancel
+              </Button>
+            </DialogFooter>
+          </>
+        )}
       </DialogContent>
     </Dialog>
   );

--- a/src/modules/runners/roster/import-library.ts
+++ b/src/modules/runners/roster/import-library.ts
@@ -1,0 +1,27 @@
+import type { IRunnerState } from '../components/runner-card/domain/runner-state';
+import type { ISavedRunner } from '@/store/runner-library.store';
+import { useRunnerLibraryStore } from '@/store/runner-library.store';
+
+export type VeteranImportCandidate = {
+  state: IRunnerState;
+  notes: string;
+};
+
+export function appendVeteransToLibrary(candidates: VeteranImportCandidate[]): number {
+  if (candidates.length === 0) return 0;
+
+  const now = Date.now();
+  const runners: ISavedRunner[] = candidates.map((candidate, index) => ({
+    ...candidate.state,
+    notes: candidate.notes,
+    id: `${now}-${index}-${Math.random().toString(36).slice(2, 9)}`,
+    createdAt: now,
+    updatedAt: now
+  }));
+
+  useRunnerLibraryStore.setState((state) => ({
+    runners: [...state.runners, ...runners]
+  }));
+
+  return runners.length;
+}

--- a/src/modules/runners/roster/types.ts
+++ b/src/modules/runners/roster/types.ts
@@ -7,6 +7,7 @@ export type IDecodedRunner = {
   displayInfo: { name: string; outfit: string } | null;
   imageUrl: string;
   searchText: string;
+  importNotes?: string;
 };
 
 export type IAptitudeSlotKey =

--- a/src/modules/runners/umadump/import-dialog.tsx
+++ b/src/modules/runners/umadump/import-dialog.tsx
@@ -1,0 +1,242 @@
+import { useCallback, useMemo, useRef, useState } from 'react';
+import { FileJson2, Upload } from 'lucide-react';
+import { toast } from 'sonner';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle
+} from '@/components/ui/dialog';
+import { ImportRunnerPicker } from '../roster/components/import-runner-picker';
+import { appendVeteransToLibrary } from '../roster/import-library';
+import type { IDecodedRunner } from '../roster/types';
+import { useRunnerLibraryStore } from '@/store/runner-library.store';
+import {
+  parseUmadumpTrainedCharaJson,
+  veteranBuildFingerprint,
+  type ParseUmadumpResult
+} from './parser';
+
+type UmadumpImportDialogProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+};
+
+type ParsedPreview = Extract<ParseUmadumpResult, { ok: true }>;
+
+export function UmadumpImportDialog(props: Readonly<UmadumpImportDialogProps>) {
+  const { open, onOpenChange } = props;
+  const [preview, setPreview] = useState<ParsedPreview | null>(null);
+  const [fileName, setFileName] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [isDragging, setIsDragging] = useState(false);
+  const [isReading, setIsReading] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const readRequestRef = useRef(0);
+  const savedRunners = useRunnerLibraryStore((state) => state.runners);
+
+  const reset = useCallback(() => {
+    readRequestRef.current++;
+    setPreview(null);
+    setFileName('');
+    setError(null);
+    setIsDragging(false);
+    setIsReading(false);
+  }, []);
+
+  const handleOpenChange = useCallback(
+    (next: boolean) => {
+      if (!next) reset();
+      onOpenChange(next);
+    },
+    [onOpenChange, reset]
+  );
+
+  const handleFile = useCallback(async (file: File) => {
+    const requestId = ++readRequestRef.current;
+    setFileName(file.name);
+    setError(null);
+    setPreview(null);
+    setIsReading(true);
+
+    try {
+      const raw = await file.text();
+      if (requestId !== readRequestRef.current) return;
+
+      const result = parseUmadumpTrainedCharaJson(raw);
+      if (result.ok) setPreview(result);
+      else setError(result.error);
+    } catch {
+      if (requestId === readRequestRef.current) {
+        setError('The file could not be read. Choose trained_chara_data.json again.');
+      }
+    } finally {
+      if (requestId === readRequestRef.current) setIsReading(false);
+    }
+  }, []);
+
+  const existingFingerprints = useMemo(
+    () => new Set(savedRunners.map(veteranBuildFingerprint)),
+    [savedRunners]
+  );
+
+  const disabledIndices = useMemo(() => {
+    if (!preview) return new Set<number>();
+    return new Set(
+      preview.runners.flatMap((runner, index) =>
+        existingFingerprints.has(veteranBuildFingerprint(runner.state)) ? [index] : []
+      )
+    );
+  }, [existingFingerprints, preview]);
+
+  const initialSelectedIndices = useMemo(() => {
+    if (!preview) return [];
+    return preview.runners.flatMap((_, index) => (disabledIndices.has(index) ? [] : [index]));
+  }, [disabledIndices, preview]);
+
+  const handleImport = useCallback(
+    (runners: IDecodedRunner[]) => {
+      const count = appendVeteransToLibrary(
+        runners.map((runner) => ({
+          state: runner.state,
+          notes: runner.importNotes ?? 'Imported from umadump'
+        }))
+      );
+      toast.success(`Imported ${count} runner${count === 1 ? '' : 's'} to Veterans`);
+      handleOpenChange(false);
+    },
+    [handleOpenChange]
+  );
+
+  const dropZone = (
+    <div
+      className={`flex cursor-pointer flex-col items-center gap-2 rounded-lg border-2 border-dashed p-5 transition-colors ${
+        isDragging ? 'border-primary bg-primary/10' : 'border-muted-foreground/30'
+      }`}
+      role="button"
+      tabIndex={0}
+      aria-label="Choose umadump trained character JSON file"
+      aria-busy={isReading}
+      onDragOver={(event) => {
+        event.preventDefault();
+        setIsDragging(true);
+      }}
+      onDragLeave={(event) => {
+        event.preventDefault();
+        setIsDragging(false);
+      }}
+      onDrop={(event) => {
+        event.preventDefault();
+        setIsDragging(false);
+        const file = event.dataTransfer.files[0];
+        if (file) void handleFile(file);
+      }}
+      onClick={() => fileInputRef.current?.click()}
+      onKeyDown={(event) => {
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault();
+          fileInputRef.current?.click();
+        }
+      }}
+    >
+      <Upload className="size-8 text-muted-foreground" />
+      <span className="text-center text-sm text-muted-foreground">
+        Drop trained_chara_data.json or click to browse
+      </span>
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept=".json,application/json"
+        className="hidden"
+        onChange={(event) => {
+          const file = event.target.files?.[0];
+          if (file) void handleFile(file);
+          event.target.value = '';
+        }}
+      />
+    </div>
+  );
+
+  const sourceContent = preview ? (
+    <>
+      {dropZone}
+      <div className="space-y-1 rounded-md bg-muted/50 p-3 text-sm">
+        <div className="flex items-center gap-2 font-medium">
+          <FileJson2 className="size-4" />
+          <span className="truncate">{fileName}</span>
+        </div>
+        <div className="text-xs text-muted-foreground">
+          {preview.runners.length} trained character
+          {preview.runners.length === 1 ? '' : 's'} found
+        </div>
+        {disabledIndices.size > 0 && (
+          <div className="text-xs text-muted-foreground">
+            {disabledIndices.size} already in Veterans and skipped
+          </div>
+        )}
+        {(preview.skippedEntries > 0 || preview.skippedSkills > 0) && (
+          <div className="text-xs text-destructive">
+            Skipped {preview.skippedEntries} malformed runner
+            {preview.skippedEntries === 1 ? '' : 's'} and {preview.skippedSkills} malformed skill
+            {preview.skippedSkills === 1 ? '' : 's'}
+          </div>
+        )}
+      </div>
+    </>
+  ) : null;
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent
+        className={`max-h-[calc(100dvh-2rem)] overflow-y-auto ${preview ? 'max-w-5xl!' : 'max-w-2xl!'}`}
+      >
+        <DialogHeader>
+          <DialogTitle>Import from umadump</DialogTitle>
+          <DialogDescription>
+            Choose the trained_chara_data.json file created by umadump. It stays in your browser and
+            is never uploaded.
+          </DialogDescription>
+        </DialogHeader>
+
+        {preview && sourceContent ? (
+          <ImportRunnerPicker
+            key={`${fileName}-${preview.runners.length}`}
+            runners={preview.runners}
+            sourceContent={sourceContent}
+            initialSelectedIndices={initialSelectedIndices}
+            disabledIndices={disabledIndices}
+            onCancel={() => handleOpenChange(false)}
+            onImport={handleImport}
+          />
+        ) : (
+          <>
+            <div className="flex flex-col gap-3">
+              {dropZone}
+              {isReading && (
+                <div role="status" className="p-3 text-center text-sm text-muted-foreground">
+                  Reading trained characters…
+                </div>
+              )}
+              {error && (
+                <div
+                  role="alert"
+                  className="rounded-md border border-destructive/30 bg-destructive/10 p-3 text-sm text-destructive"
+                >
+                  {error}
+                </div>
+              )}
+            </div>
+            <DialogFooter>
+              <Button variant="outline" onClick={() => handleOpenChange(false)}>
+                Cancel
+              </Button>
+            </DialogFooter>
+          </>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/modules/runners/umadump/parser.test.ts
+++ b/src/modules/runners/umadump/parser.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from 'vitest';
+import { StrategyName, Strategy } from '@/lib/uma-domain/runner/definitions';
+import { parseUmadumpTrainedCharaJson, veteranBuildFingerprint } from './parser';
+
+const trainedChara = {
+  viewer_id: 311943848596,
+  trained_chara_id: 12,
+  card_id: 100401,
+  speed: 987,
+  stamina: 445,
+  power: 608,
+  wiz: 372,
+  guts: 364,
+  rank_score: 7466,
+  proper_ground_turf: 7,
+  proper_ground_dirt: 4,
+  proper_running_style_nige: 7,
+  proper_running_style_senko: 3,
+  proper_running_style_sashi: 2,
+  proper_running_style_oikomi: 1,
+  proper_distance_short: 7,
+  proper_distance_mile: 7,
+  proper_distance_middle: 7,
+  proper_distance_long: 6,
+  talent_level: 2,
+  running_style: 1,
+  create_time: '2025-07-10 03:21:45',
+  skill_array: [
+    { skill_id: 100041, level: 2 },
+    { skill_id: 200142, level: 1 }
+  ],
+  support_card_list: [{ support_card_id: 30002 }],
+  memo: 'MemoExample'
+};
+
+describe('parseUmadumpTrainedCharaJson', () => {
+  it('preserves the Veteran fields provided by trained_chara_data.json', () => {
+    const result = parseUmadumpTrainedCharaJson(JSON.stringify([trainedChara]));
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    expect(result.skippedEntries).toBe(0);
+    expect(result.skippedSkills).toBe(0);
+    expect(result.runners[0]).toMatchObject({
+      importNotes: 'MemoExample',
+      state: {
+        outfitId: '100401',
+        speed: 987,
+        stamina: 445,
+        power: 608,
+        guts: 364,
+        wisdom: 372,
+        strategy: StrategyName[Strategy.FrontRunner],
+        rankScore: 7466,
+        star: 2,
+        skills: ['100041', '200142'],
+        skillLevels: { '100041': 2, '200142': 1 },
+        aptitudes: {
+          distanceShort: 'A',
+          distanceMile: 'A',
+          distanceMiddle: 'A',
+          distanceLong: 'B',
+          turf: 'A',
+          dirt: 'D',
+          nige: 'A',
+          senko: 'E',
+          sashi: 'F',
+          oikomi: 'G'
+        }
+      }
+    });
+  });
+
+  it('rejects invalid JSON, non-array roots, and empty dumps with actionable errors', () => {
+    expect(parseUmadumpTrainedCharaJson('{').ok).toBe(false);
+    expect(parseUmadumpTrainedCharaJson('{}')).toEqual({
+      ok: false,
+      error: 'This is not an umadump trained-character file. Expected a JSON array.'
+    });
+    expect(parseUmadumpTrainedCharaJson('[]')).toEqual({
+      ok: false,
+      error: 'This umadump file contains no trained characters.'
+    });
+  });
+
+  it('keeps usable runners while reporting malformed entries and skills', () => {
+    const result = parseUmadumpTrainedCharaJson(
+      JSON.stringify([
+        { card_id: 123 },
+        {
+          ...trainedChara,
+          memo: '  ',
+          running_style: 3,
+          skill_array: [
+            { skill_id: 100041, skill_level: 3 },
+            { skill_id: 0, level: 1 },
+            { skill_id: 200142, level: 0 }
+          ],
+          extra_data: { future: true }
+        }
+      ])
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    expect(result.skippedEntries).toBe(1);
+    expect(result.skippedSkills).toBe(2);
+    expect(result.runners[0].importNotes).toBe('Imported from umadump');
+    expect(result.runners[0].state.strategy).toBe(StrategyName[Strategy.LateSurger]);
+    expect(result.runners[0].state.skillLevels).toEqual({ '100041': 3 });
+  });
+});
+
+describe('veteranBuildFingerprint', () => {
+  it('ignores skill order and local-only presentation metadata', () => {
+    const result = parseUmadumpTrainedCharaJson(JSON.stringify([trainedChara]));
+    if (!result.ok) throw new Error(result.error);
+    const runner = result.runners[0].state;
+
+    const reordered = {
+      ...runner,
+      skills: runner.skills.toReversed(),
+      randomMobId: 9999,
+      linkedRunnerId: 'local-link'
+    };
+
+    expect(veteranBuildFingerprint(reordered)).toBe(veteranBuildFingerprint(runner));
+  });
+});

--- a/src/modules/runners/umadump/parser.ts
+++ b/src/modules/runners/umadump/parser.ts
@@ -1,0 +1,222 @@
+import type { IStrategyName } from '@/lib/uma-domain/runner/definitions';
+import { Strategy, StrategyName } from '@/lib/uma-domain/runner/definitions';
+import type { IRunnerState, RunnerAptitudes } from '../components/runner-card/domain/runner-state';
+import { buildDecodedRunner } from '../roster/helpers';
+import type { IDecodedRunner } from '../roster/types';
+import type { ISingleExportData, ISingleExportSkill } from '../share/types';
+
+const REQUIRED_NUMBER_FIELDS = ['card_id', 'speed', 'stamina', 'power', 'guts', 'wiz'] as const;
+
+const APTITUDE_FIELDS = [
+  'proper_distance_short',
+  'proper_distance_mile',
+  'proper_distance_middle',
+  'proper_distance_long',
+  'proper_ground_turf',
+  'proper_ground_dirt',
+  'proper_running_style_nige',
+  'proper_running_style_senko',
+  'proper_running_style_sashi',
+  'proper_running_style_oikomi'
+] as const;
+
+const STRATEGY_BY_RUNNING_STYLE: Partial<Record<number, IStrategyName>> = {
+  [Strategy.FrontRunner]: StrategyName[Strategy.FrontRunner],
+  [Strategy.PaceChaser]: StrategyName[Strategy.PaceChaser],
+  [Strategy.LateSurger]: StrategyName[Strategy.LateSurger],
+  [Strategy.EndCloser]: StrategyName[Strategy.EndCloser],
+  [Strategy.Runaway]: StrategyName[Strategy.Runaway]
+};
+
+type UmadumpDecodedRunner = IDecodedRunner & {
+  importNotes: string;
+};
+
+export type ParseUmadumpResult =
+  | {
+      ok: true;
+      runners: UmadumpDecodedRunner[];
+      skippedEntries: number;
+      skippedSkills: number;
+    }
+  | { ok: false; error: string };
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isNonNegativeInteger(value: unknown): value is number {
+  return typeof value === 'number' && Number.isInteger(value) && value >= 0;
+}
+
+function isPositiveInteger(value: unknown): value is number {
+  return isNonNegativeInteger(value) && value > 0;
+}
+
+function hasValidCoreFields(entry: Record<string, unknown>): boolean {
+  for (const key of REQUIRED_NUMBER_FIELDS) {
+    const value = entry[key];
+    if (!isNonNegativeInteger(value) || (key === 'card_id' && value === 0)) return false;
+  }
+
+  for (const key of APTITUDE_FIELDS) {
+    const value = entry[key];
+    if (!isPositiveInteger(value) || value > 8) return false;
+  }
+
+  return Array.isArray(entry.skill_array);
+}
+
+function normalizeSkills(value: unknown[]): { skills: ISingleExportSkill[]; skipped: number } {
+  const byId = new Map<number, ISingleExportSkill>();
+  let skipped = 0;
+
+  for (const rawSkill of value) {
+    if (!isRecord(rawSkill) || !isPositiveInteger(rawSkill.skill_id)) {
+      skipped++;
+      continue;
+    }
+
+    const rawLevel = rawSkill.level ?? rawSkill.skill_level;
+    if (!isPositiveInteger(rawLevel)) {
+      skipped++;
+      continue;
+    }
+
+    byId.set(rawSkill.skill_id, {
+      skill_id: rawSkill.skill_id,
+      skill_level: rawLevel
+    });
+  }
+
+  return { skills: [...byId.values()], skipped };
+}
+
+function optionalInteger(value: unknown, min: number, max: number): number | undefined {
+  if (typeof value !== 'number' || !Number.isInteger(value) || value < min || value > max) {
+    return undefined;
+  }
+  return value;
+}
+
+function toDecodedRunner(entry: Record<string, unknown>, skills: ISingleExportSkill[]) {
+  const source: ISingleExportData = {
+    card_id: entry.card_id as number,
+    speed: entry.speed as number,
+    stamina: entry.stamina as number,
+    power: entry.power as number,
+    guts: entry.guts as number,
+    wiz: entry.wiz as number,
+    proper_distance_short: entry.proper_distance_short as number,
+    proper_distance_mile: entry.proper_distance_mile as number,
+    proper_distance_middle: entry.proper_distance_middle as number,
+    proper_distance_long: entry.proper_distance_long as number,
+    proper_ground_turf: entry.proper_ground_turf as number,
+    proper_ground_dirt: entry.proper_ground_dirt as number,
+    proper_running_style_nige: entry.proper_running_style_nige as number,
+    proper_running_style_senko: entry.proper_running_style_senko as number,
+    proper_running_style_sashi: entry.proper_running_style_sashi as number,
+    proper_running_style_oikomi: entry.proper_running_style_oikomi as number,
+    create_time: typeof entry.create_time === 'string' ? entry.create_time : '',
+    rank_score: optionalInteger(entry.rank_score, 0, Number.MAX_SAFE_INTEGER),
+    skill_array: skills
+  };
+
+  const decoded = buildDecodedRunner(source);
+  const runningStyle = optionalInteger(entry.running_style, 1, 5);
+  const talentLevel = optionalInteger(entry.talent_level, 1, 5);
+  const memo = typeof entry.memo === 'string' ? entry.memo.trim() : '';
+
+  return {
+    ...decoded,
+    state: {
+      ...decoded.state,
+      strategy:
+        (runningStyle === undefined ? undefined : STRATEGY_BY_RUNNING_STYLE[runningStyle]) ??
+        StrategyName[Strategy.FrontRunner],
+      rankScore: source.rank_score ?? null,
+      star: talentLevel ?? null
+    },
+    importNotes: memo || 'Imported from umadump'
+  } satisfies UmadumpDecodedRunner;
+}
+
+export function parseUmadumpTrainedCharaJson(raw: string): ParseUmadumpResult {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return {
+      ok: false,
+      error: 'This file is not valid JSON. Choose the trained_chara_data.json file from umadump.'
+    };
+  }
+
+  if (!Array.isArray(parsed)) {
+    return {
+      ok: false,
+      error: 'This is not an umadump trained-character file. Expected a JSON array.'
+    };
+  }
+
+  const runners: UmadumpDecodedRunner[] = [];
+  let skippedEntries = 0;
+  let skippedSkills = 0;
+
+  for (const entry of parsed) {
+    if (!isRecord(entry) || !hasValidCoreFields(entry)) {
+      skippedEntries++;
+      continue;
+    }
+
+    const normalized = normalizeSkills(entry.skill_array as unknown[]);
+    skippedSkills += normalized.skipped;
+    runners.push(toDecodedRunner(entry, normalized.skills));
+  }
+
+  if (runners.length === 0) {
+    return {
+      ok: false,
+      error:
+        parsed.length === 0
+          ? 'This umadump file contains no trained characters.'
+          : 'No usable trained characters were found. Check that this is trained_chara_data.json.'
+    };
+  }
+
+  return { ok: true, runners, skippedEntries, skippedSkills };
+}
+
+function expandedAptitudes(runner: IRunnerState): RunnerAptitudes {
+  return (
+    runner.aptitudes ?? {
+      distanceShort: runner.distanceAptitude,
+      distanceMile: runner.distanceAptitude,
+      distanceMiddle: runner.distanceAptitude,
+      distanceLong: runner.distanceAptitude,
+      turf: runner.surfaceAptitude,
+      dirt: runner.surfaceAptitude,
+      nige: runner.strategyAptitude,
+      senko: runner.strategyAptitude,
+      sashi: runner.strategyAptitude,
+      oikomi: runner.strategyAptitude
+    }
+  );
+}
+
+/** Stable identity for one functional Veteran build; notes and local library metadata are excluded. */
+export function veteranBuildFingerprint(runner: IRunnerState): string {
+  const skills = [...new Set(runner.skills)]
+    .sort((left, right) => left.localeCompare(right))
+    .map((skillId) => [skillId, runner.skillLevels?.[skillId] ?? 1]);
+
+  return JSON.stringify({
+    outfitId: runner.outfitId,
+    stats: [runner.speed, runner.stamina, runner.power, runner.guts, runner.wisdom],
+    strategy: runner.strategy,
+    aptitudes: expandedAptitudes(runner),
+    rankScore: runner.rankScore ?? null,
+    star: runner.star ?? null,
+    skills
+  });
+}

--- a/src/modules/skills/components/skill-list/skill-item/actions.tsx
+++ b/src/modules/skills/components/skill-list/skill-item/actions.tsx
@@ -72,32 +72,6 @@ export function SkillItemDetailsActions(props: Readonly<SkillItemDetailsActionsP
 
   return (
     <>
-      {/* <Popover open={detailsOpen} onOpenChange={setDetailsOpen}>
-        <PopoverTrigger
-          render={
-            <Button
-              variant="ghost"
-              size="icon-lg"
-              title="Show skill details"
-              onClick={(event) => event.stopPropagation()}
-            >
-              <CircleHelp />
-            </Button>
-          }
-        />
-
-        {detailsOpen && (
-          <PopoverContent align="start" side="right" className="w-[300px] p-0">
-            <ExpandedSkillDetails
-              id={skillId}
-              skill={skill}
-              distanceFactor={distanceFactor}
-              valueScalingContext={valueScalingContext}
-            />
-          </PopoverContent>
-        )}
-      </Popover> */}
-
       {dismissable && (
         <Button
           variant="ghost"

--- a/src/routes/runners/home.tsx
+++ b/src/routes/runners/home.tsx
@@ -1,7 +1,7 @@
 import { useNavigate } from 'react-router';
 
 import { Activity, useReducer, useMemo, useCallback } from 'react';
-import { Camera, Import, Plus, Search, Trash2, Users, X } from 'lucide-react';
+import { Camera, FileJson2, Import, Plus, Search, Trash2, Users, X } from 'lucide-react';
 import type { ISavedRunner } from '@/store/runner-library.store';
 import { Button } from '@/components/ui/button';
 import { FloatingButton } from '@/components/ui/fab';
@@ -42,6 +42,7 @@ import {
 } from '@/components/ui/dialog';
 import { getCompareFieldId, loadRunnerFromLibrary, showRunner } from '@/store/runners.store';
 import { RosterImportDialog } from '@/modules/runners/roster/import-dialog';
+import { UmadumpImportDialog } from '@/modules/runners/umadump/import-dialog';
 import { getUmaDisplayInfo } from '@/modules/runners/utils';
 import { aptitudeNames, strategyNames } from '@/lib/uma-domain/runner/definitions';
 import { useIsMobile } from '@/hooks/use-mobile';
@@ -96,6 +97,7 @@ type RosterHomeState = {
   loadDialogOpen: boolean;
   runnerToLoad: ISavedRunner | null;
   rosterImportOpen: boolean;
+  umadumpImportOpen: boolean;
   ocrImportOpen: boolean;
   search: string;
   strategyFilter: string;
@@ -113,6 +115,7 @@ type RosterHomeAction =
   | { type: 'load:dialogOpenChange'; open: boolean }
   | { type: 'load:completed' }
   | { type: 'rosterImport:openChange'; open: boolean }
+  | { type: 'umadumpImport:openChange'; open: boolean }
   | { type: 'ocrImport:openChange'; open: boolean }
   | { type: 'search:set'; value: string }
   | { type: 'filter:strategy'; value: string }
@@ -134,6 +137,7 @@ function createInitialRosterHomeState(): RosterHomeState {
     loadDialogOpen: false,
     runnerToLoad: null,
     rosterImportOpen: false,
+    umadumpImportOpen: false,
     ocrImportOpen: false,
     search: '',
     strategyFilter: 'all',
@@ -176,6 +180,8 @@ function rosterHomeReducer(state: RosterHomeState, action: RosterHomeAction): Ro
       return { ...state, loadDialogOpen: false, runnerToLoad: null };
     case 'rosterImport:openChange':
       return { ...state, rosterImportOpen: action.open };
+    case 'umadumpImport:openChange':
+      return { ...state, umadumpImportOpen: action.open };
     case 'ocrImport:openChange':
       return { ...state, ocrImportOpen: action.open };
     case 'search:set':
@@ -404,23 +410,36 @@ export default function RosterHomePage() {
         {/* [Desktop] Actions */}
         {!isMobile && (
           <div className="flex items-center gap-2">
-            <Button
-              size="default"
-              variant="outline"
-              onClick={() => dispatch({ type: 'rosterImport:openChange', open: true })}
-            >
-              <Import />
-              Import Roster
-            </Button>
-
-            <Button
-              size="default"
-              variant="outline"
-              onClick={() => dispatch({ type: 'ocrImport:openChange', open: true })}
-            >
-              <Camera />
-              Import Screenshot
-            </Button>
+            <DropdownMenu>
+              <DropdownMenuTrigger
+                render={
+                  <Button size="default" variant="outline">
+                    <Import />
+                    Import
+                  </Button>
+                }
+              />
+              <DropdownMenuContent align="end" className="w-52">
+                <DropdownMenuItem
+                  onClick={() => dispatch({ type: 'rosterImport:openChange', open: true })}
+                >
+                  <Import className="size-4" />
+                  RosterView code
+                </DropdownMenuItem>
+                <DropdownMenuItem
+                  onClick={() => dispatch({ type: 'umadumpImport:openChange', open: true })}
+                >
+                  <FileJson2 className="size-4" />
+                  umadump JSON
+                </DropdownMenuItem>
+                <DropdownMenuItem
+                  onClick={() => dispatch({ type: 'ocrImport:openChange', open: true })}
+                >
+                  <Camera className="size-4" />
+                  Screenshot
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
 
             <Activity mode={runners.length > 0 ? 'visible' : 'hidden'}>
               <Button size="default" onClick={handleAddNew}>
@@ -497,6 +516,12 @@ export default function RosterHomePage() {
                 Import Roster
               </DropdownMenuItem>
               <DropdownMenuItem
+                onClick={() => dispatch({ type: 'umadumpImport:openChange', open: true })}
+              >
+                <FileJson2 className="size-4" />
+                Import umadump JSON
+              </DropdownMenuItem>
+              <DropdownMenuItem
                 onClick={() => dispatch({ type: 'ocrImport:openChange', open: true })}
               >
                 <Camera className="size-4" />
@@ -566,13 +591,36 @@ export default function RosterHomePage() {
 
           <EmptyContent>
             <div className="flex items-center gap-2">
-              <Button
-                variant="outline"
-                onClick={() => dispatch({ type: 'ocrImport:openChange', open: true })}
-              >
-                <Camera className="mr-2" />
-                Import Screenshot
-              </Button>
+              <DropdownMenu>
+                <DropdownMenuTrigger
+                  render={
+                    <Button variant="outline">
+                      <Import />
+                      Import
+                    </Button>
+                  }
+                />
+                <DropdownMenuContent align="center" className="w-52">
+                  <DropdownMenuItem
+                    onClick={() => dispatch({ type: 'rosterImport:openChange', open: true })}
+                  >
+                    <Import className="size-4" />
+                    RosterView code
+                  </DropdownMenuItem>
+                  <DropdownMenuItem
+                    onClick={() => dispatch({ type: 'umadumpImport:openChange', open: true })}
+                  >
+                    <FileJson2 className="size-4" />
+                    umadump JSON
+                  </DropdownMenuItem>
+                  <DropdownMenuItem
+                    onClick={() => dispatch({ type: 'ocrImport:openChange', open: true })}
+                  >
+                    <Camera className="size-4" />
+                    Screenshot
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
               <Button onClick={handleAddNew}>
                 <Plus className="mr-2" />
                 Add Runner
@@ -692,6 +740,11 @@ export default function RosterHomePage() {
       <RosterImportDialog
         open={page.rosterImportOpen}
         onOpenChange={(open) => dispatch({ type: 'rosterImport:openChange', open })}
+      />
+
+      <UmadumpImportDialog
+        open={page.umadumpImportOpen}
+        onOpenChange={(open) => dispatch({ type: 'umadumpImport:openChange', open })}
       />
 
       <OcrImportDialog


### PR DESCRIPTION
Adds `trained_chara_data.json` as a Veteran import source so players can move builds from umadump into Torena without translating them through RosterView.

## Import flow

```mermaid
flowchart LR
  J["trained_chara_data.json"] --> P{{"validate & normalize"}}
  P -->|invalid row or skill| W["preview warning"]
  P -->|valid| R["runner state<br/>stats, aptitudes, skills"]
  R --> D{{"already saved?"}}
  D -->|yes| S["disabled as duplicate"]
  D -->|no| V["search, filter & select"]
  V --> L["Veterans library"]
```

## What's here

- **`runners/umadump`** — validates the dump, maps full aptitude buckets, strategy, rank score, stars, skill levels, and memo, then provides the file-drop preview.
- **Shared roster importer** — centralizes virtualized selection, aptitude filters, duplicate states, and batched library writes for RosterView and umadump.
- **Veterans home** — consolidates RosterView, umadump, and screenshot sources under one Import menu on desktop, mobile, and the empty state.
- **Filter fix** — makes Base UI aptitude triggers controlled and renders grade labels instead of stale raw values.
- **Skill action cleanup** — removes obsolete commented skill-detail UI.

## Gates

Typecheck ✅ · 563 tests ✅ · intent ✅ · production build ✅ · targeted lint 0 errors.

## Caveats

- Malformed rows and skills are skipped and counted in the preview rather than failing the whole dump.
- Exact existing builds are shown as already saved and cannot be selected again.

> Expected noise: the duplication hook reports the repository's existing clone inventory (112 groups); the hook completes successfully.
